### PR TITLE
Precompile failure

### DIFF
--- a/include/evmc.h
+++ b/include/evmc.h
@@ -151,9 +151,7 @@ enum evmc_status_code {
     EVMC_REVERT = 7,                ///< Execution terminated with REVERT opcode.
 
     /// Tried to execute an operation which is restricted in static mode.
-    ///
-    /// @todo Avoid _ERROR suffix that suggests fatal error.
-    EVMC_STATIC_MODE_ERROR = 8,
+    EVMC_STATIC_MODE_VIOLATION = 8,
 
     /// The dedicated INVALID instruction was hit.
     EVMC_INVALID_INSTRUCTION = 9,

--- a/include/evmc.h
+++ b/include/evmc.h
@@ -163,6 +163,11 @@ enum evmc_status_code {
     /// An example is RETURNDATACOPY reading past the available buffer.
     EVMC_INVALID_MEMORY_ACCESS = 10,
 
+    /// Exceptions produced by precompiles/system contracts
+    ///
+    /// An example: elliptic curve functions handed invalid EC points
+    EVMC_PRECOMPILE_FAILURE = 11,
+
     /// The EVM rejected the execution of the given code or message.
     ///
     /// This error SHOULD be used to signal that the EVM is not able to or


### PR DESCRIPTION
Fixes #16.

Actually addresses two things:

1. adding EVMC_PRECOMPILE_FAILURE
2. renaming EVMC_STATIC_MODE_ERROR