### PR TITLE
EVMC ABI 1

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -5,8 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/// Prototype from examplevm.c
-struct evmc_instance* examplevm_create(void);
+#include "examplevm/examplevm.h"
+
 
 struct evmc_uint256be balance(struct evmc_context* context,
                               const struct evmc_address* address)
@@ -139,7 +139,7 @@ static const struct evmc_context_fn_table ctx_fn_table = {
 
 /// Example how the API is supposed to be used.
 int main(int argc, char *argv[]) {
-    struct evmc_instance* jit = examplevm_create();
+    struct evmc_instance* jit = evmc_create_examplevm();
     if (jit->abi_version != EVMC_ABI_VERSION)
         return 1;  // Incompatible ABI version.
 

--- a/examples/examplevm/examplevm.c
+++ b/examples/examplevm/examplevm.c
@@ -1,4 +1,4 @@
-#include <evmc.h>
+#include "examplevm.h"
 
 #include <limits.h>
 #include <stdio.h>
@@ -109,7 +109,7 @@ static struct evmc_result execute(struct evmc_instance* instance, struct evmc_co
     return ret;
 }
 
-struct evmc_instance* examplevm_create()
+struct evmc_instance* evmc_create_examplevm()
 {
     struct evmc_instance init = {
         .abi_version = EVMC_ABI_VERSION,

--- a/examples/examplevm/examplevm.c
+++ b/examples/examplevm/examplevm.c
@@ -113,6 +113,8 @@ struct evmc_instance* examplevm_create()
 {
     struct evmc_instance init = {
         .abi_version = EVMC_ABI_VERSION,
+        .name = "examplevm",
+        .version = "0.0.0",
         .destroy = evmc_destroy,
         .execute = execute,
         .set_option = evmc_set_option,

--- a/examples/examplevm/examplevm.h
+++ b/examples/examplevm/examplevm.h
@@ -1,0 +1,13 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2018 Pawel Bylica.
+ * Licensed under the MIT License. See the LICENSE file.
+ */
+
+#pragma once
+
+#include <evmc.h>
+
+/**
+ * Creates EVMC Example VM.
+ */
+struct evmc_instance* evmc_create_examplevm(void);

--- a/include/evmc.h
+++ b/include/evmc.h
@@ -31,9 +31,10 @@ extern "C" {
 
 // BEGIN Python CFFI declarations
 
-enum {
+enum
+{
     /// The EVMC ABI version number of the interface declared in this file.
-    EVMC_ABI_VERSION = 0
+    EVMC_ABI_VERSION = 1
 };
 
 /// Big-endian 256-bit integer.
@@ -540,14 +541,12 @@ typedef struct evmc_result (*evmc_execute_fn)(struct evmc_instance* instance,
 /// The EVM instance.
 ///
 /// Defines the base struct of the EVM implementation.
-struct evmc_instance {
-
+struct evmc_instance
+{
     /// EVMC ABI version implemented by the EVM instance.
     ///
-    /// For future use to detect ABI incompatibilities. The EVMC ABI version
+    /// Used to detect ABI incompatibilities. The EVMC ABI version
     /// represented by this file is in ::EVMC_ABI_VERSION.
-    ///
-    /// @todo Consider removing this field.
     const int abi_version;
 
     /// Pointer to function destroying the EVM instance.

--- a/include/evmc.h
+++ b/include/evmc.h
@@ -549,6 +549,16 @@ struct evmc_instance
     /// represented by this file is in ::EVMC_ABI_VERSION.
     const int abi_version;
 
+    /// The name of the EVMC VM implementation.
+    ///
+    /// It MUST be a NULL-terminated not empty string.
+    const char* name;
+
+    /// The version of the EVMC VM implementation, e.g. "1.2.3b4".
+    ///
+    /// It MUST be a NULL-terminated not empty string.
+    const char* version;
+
     /// Pointer to function destroying the EVM instance.
     evmc_destroy_fn destroy;
 

--- a/include/evmc.h
+++ b/include/evmc.h
@@ -576,11 +576,11 @@ struct evmc_instance
 /// Example of a function creating an instance of an example EVM implementation.
 ///
 /// Each EVM implementation MUST provide a function returning an EVM instance.
-/// The function SHOULD be named `<vm-name>_create(void)`.
+/// The function SHOULD be named `evmc_create_<vm-name>(void)`.
 ///
 /// @return  EVM instance or NULL indicating instance creation failure.
 ///
-/// struct evmc_instance* examplevm_create(void);
+/// struct evmc_instance* evmc_create_examplevm(void);
 
 
 #if __cplusplus

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -4,6 +4,8 @@
 
 #include "vmtester.hpp"
 
+#include <cstring>
+
 TEST_F(evmc_vm_test, abi_version_match)
 {
     ASSERT_EQ(vm->abi_version, EVMC_ABI_VERSION);
@@ -27,4 +29,16 @@ TEST_F(evmc_vm_test, set_option_empty_value)
         int r = vm->set_option(vm, "unknown_option_csk9twq", nullptr);
         EXPECT_EQ(r, 0);
     }
+}
+
+TEST_F(evmc_vm_test, name)
+{
+    ASSERT_NE(vm->name, nullptr);
+    EXPECT_GT(std::strlen(vm->name), 0) << "VM name cannot be empty";
+}
+
+TEST_F(evmc_vm_test, version)
+{
+    ASSERT_NE(vm->version, nullptr);
+    EXPECT_GT(std::strlen(vm->version), 0) << "VM name cannot be empty";
 }

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -6,6 +6,25 @@
 
 #include <cstring>
 
+// Compile time checks:
+
+static_assert(sizeof(evmc_uint256be) == 32, "evmc_uint256be is too big");
+static_assert(sizeof(evmc_address) == 20, "evmc_address is too big");
+static_assert(sizeof(evmc_result) == 64, "evmc_result does not fit cache line");
+static_assert(sizeof(evmc_instance) <= 64, "evmc_instance does not fit cache line");
+static_assert(sizeof(evmc_message) <= 18 * 8, "evmc_message not optimally packed");
+static_assert(offsetof(evmc_message, code_hash) % 8 == 0, "evmc_message.code_hash not aligned");
+
+// Check enums match int size.
+// On GCC/clang the underlying type should be unsigned int, on MSVC int
+static_assert(
+    sizeof(evmc_call_kind) == sizeof(int), "Enum `evmc_call_kind` is not the size of int");
+static_assert(sizeof(evmc_revision) == sizeof(int), "Enum `evmc_revision` is not the size of int");
+
+static constexpr size_t optionalDataSize =
+    sizeof(evmc_result) - offsetof(evmc_result, create_address);
+static_assert(optionalDataSize == sizeof(evmc_result_optional_data), "");
+
 TEST_F(evmc_vm_test, abi_version_match)
 {
     ASSERT_EQ(vm->abi_version, EVMC_ABI_VERSION);

--- a/test/vmtester/vmtester.cpp
+++ b/test/vmtester/vmtester.cpp
@@ -26,12 +26,12 @@ namespace
 {
 boost::function<evmc_create_fn> create_fn;
 
-bool ends_with(const std::string& str, const std::string& ending)
+bool starts_with(const std::string& str, const std::string& prefix)
 {
-    if (str.size() < ending.size())
+    if (str.size() < prefix.size())
         return false;
 
-    return std::equal(ending.rbegin(), ending.rend(), str.rbegin());
+    return std::equal(prefix.begin(), prefix.end(), str.begin());
 }
 
 std::unique_ptr<evmc_instance, evmc_destroy_fn> create_vm()
@@ -79,10 +79,10 @@ int main(int argc, char* argv[])
 
         auto symbols = dll::library_info{vm_path}.symbols();
         auto it = std::find_if(symbols.begin(), symbols.end(),
-            [](const std::string& symbol) { return ends_with(symbol, "_create"); });
+            [](const std::string& symbol) { return starts_with(symbol, "evmc_create_"); });
         if (it == symbols.end())
         {
-            std::cerr << "EVMC create function not found it " << vm_path.string() << "\n";
+            std::cerr << "EVMC create function not found in " << vm_path.string() << "\n";
             return 2;
         }
         const std::string& create_fn_name = *it;


### PR DESCRIPTION
1. It introduces "name" and "version" fields in evmc_instance. This should be useful for dynamic loaded VM.
2. The naming convention for "create" function changed to be `evmc_create_` prefixed.
3. ABI version bumped to 1.

Fixes #10.