### PR TITLE
include/evmc: add status code EVMC_CALL_DEPTH_EXCEDED

### DIFF
--- a/include/evmc.h
+++ b/include/evmc.h
@@ -167,6 +167,9 @@ enum evmc_status_code {
     /// An example: elliptic curve functions handed invalid EC points
     EVMC_PRECOMPILE_FAILURE = 11,
 
+    /// Call depth exceded (if there is a call depth limit)
+    EVMC_CALL_DEPTH_EXCEDED = 12,
+
     /// The EVM rejected the execution of the given code or message.
     ///
     /// This error SHOULD be used to signal that the EVM is not able to or


### PR DESCRIPTION
Would like to get this in before #23 so that it can be placed correctly in the order as well.