### PR TITLE
Entrypoint alias

### DIFF
--- a/examples/examplevm/CMakeLists.txt
+++ b/examples/examplevm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# EVMC -- Ethereum Client-VM Connector API
+# EVMC: Ethereum Client-VM Connector API
 # Copyright 2018 Pawel Bylica.
 # Licensed under the MIT License. See the LICENSE file.
 
@@ -6,9 +6,16 @@ include(GNUInstallDirs)
 
 add_library(evmc-examplevm examplevm.c)
 target_link_libraries(evmc-examplevm PRIVATE evmc)
-set_target_properties(evmc-examplevm PROPERTIES DEBUG_POSTFIX "")
+set_target_properties(
+    evmc-examplevm PROPERTIES
+    DEBUG_POSTFIX ""
+    RUNTIME_OUTPUT_DIRECTORY ..
+    LIBRARY_OUTPUT_DIRECTORY ..
+)
 
-install(TARGETS evmc-examplevm
+install(
+    TARGETS evmc-examplevm
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/examples/examplevm/examplevm.c
+++ b/examples/examplevm/examplevm.c
@@ -11,7 +11,7 @@ struct examplevm
     int verbose;
 };
 
-static void evmc_destroy(struct evmc_instance* evm)
+static void destroy(struct evmc_instance* evm)
 {
     free(evm);
 }
@@ -19,7 +19,7 @@ static void evmc_destroy(struct evmc_instance* evm)
 /// Example options.
 ///
 /// VMs are allowed to omit this function implementation.
-int evmc_set_option(struct evmc_instance* instance, char const* name, char const* value)
+static int set_option(struct evmc_instance* instance, char const* name, char const* value)
 {
     struct examplevm* vm = (struct examplevm*)instance;
     if (strcmp(name, "verbose") == 0)
@@ -34,7 +34,7 @@ int evmc_set_option(struct evmc_instance* instance, char const* name, char const
     return 0;
 }
 
-static void evmc_release_result(struct evmc_result const* result)
+static void release_result(struct evmc_result const* result)
 {
     (void)result;
 }
@@ -103,7 +103,7 @@ static struct evmc_result execute(struct evmc_instance* instance,
         return ret;
     }
 
-    ret.release = evmc_release_result;
+    ret.release = release_result;
     ret.status_code = EVMC_FAILURE;
     ret.gas_left = 0;
 
@@ -119,9 +119,9 @@ struct evmc_instance* evmc_create_examplevm()
         .abi_version = EVMC_ABI_VERSION,
         .name = "examplevm",
         .version = "0.0.0",
-        .destroy = evmc_destroy,
+        .destroy = destroy,
         .execute = execute,
-        .set_option = evmc_set_option,
+        .set_option = set_option,
     };
     struct examplevm* vm = calloc(1, sizeof(struct examplevm));
     struct evmc_instance* interface = &vm->instance;

--- a/examples/examplevm/examplevm.c
+++ b/examples/examplevm/examplevm.c
@@ -1,5 +1,7 @@
 #include "examplevm.h"
 
+#include <evmc/utils.h>
+
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -128,3 +130,5 @@ struct evmc_instance* evmc_create_examplevm()
     memcpy(interface, &init, sizeof(init));
     return interface;
 }
+
+EVMC_ENTRYPOINT(evmc_create_examplevm)

--- a/include/evmc/utils.h
+++ b/include/evmc/utils.h
@@ -1,0 +1,19 @@
+/* EVMC: Ethereum Client-VM Connector API.
+ * Copyright 2018 Pawel Bylica.
+ * Licensed under the MIT License. See the LICENSE file.
+ */
+
+#pragma once
+
+#if __cplusplus
+#define EVMC_EXTERNC extern "C"
+#else
+#define EVMC_EXTERNC
+#endif
+
+#if _MSC_VER
+#define EVMC_ENTRYPOINT(function_name)
+#else
+#define EVMC_ENTRYPOINT(function_name) \
+    EVMC_EXTERNC struct evmc_instance* evmc_create() __attribute__((weak, alias(#function_name)));
+#endif

--- a/test/vmtester/CMakeLists.txt
+++ b/test/vmtester/CMakeLists.txt
@@ -8,6 +8,7 @@ hunter_add_package(Boost COMPONENTS program_options filesystem system)
 find_package(Boost CONFIG REQUIRED program_options filesystem system)
 
 add_executable(evmc-vmtester vmtester.hpp vmtester.cpp tests.cpp)
+set_target_properties(evmc-vmtester PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 
 target_link_libraries(
     evmc-vmtester


### PR DESCRIPTION
This adds a helper macro that creates the symbol alias "evmc_create" for the given EVMC create function.