### PR TITLE
Storage status

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -45,10 +45,10 @@ static void get_storage(struct evmc_uint256be* result,
     printf("\n");
 }
 
-static void set_storage(struct evmc_context* context,
-                        const struct evmc_address* address,
-                        const struct evmc_uint256be* key,
-                        const struct evmc_uint256be* value)
+static enum evmc_storage_status set_storage(struct evmc_context* context,
+                                            const struct evmc_address* address,
+                                            const struct evmc_uint256be* key,
+                                            const struct evmc_uint256be* value)
 {
     (void)context;
     (void)key;
@@ -56,6 +56,7 @@ static void set_storage(struct evmc_context* context,
     printf("EVM-C: SSTORE @");
     print_address(address);
     printf("\n");
+    return EVMC_STORAGE_UNCHANGED;
 }
 
 static void get_balance(struct evmc_uint256be* result,

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -142,14 +142,12 @@ static void get_block_hash(struct evmc_uint256be* result,
 }
 
 /// EVM log callback.
-///
-/// @note The `evm_log` name is used to avoid conflict with `log()` C function.
-static void evm_log(struct evmc_context* context,
-                    const struct evmc_address* address,
-                    const uint8_t* data,
-                    size_t data_size,
-                    const struct evmc_uint256be topics[],
-                    size_t topics_count)
+static void emit_log(struct evmc_context* context,
+                     const struct evmc_address* address,
+                     const uint8_t* data,
+                     size_t data_size,
+                     const struct evmc_uint256be topics[],
+                     size_t topics_count)
 {
     (void)context;
     (void)address;
@@ -161,7 +159,7 @@ static void evm_log(struct evmc_context* context,
 
 static const struct evmc_context_fn_table ctx_fn_table = {
     account_exists, get_storage,  set_storage, get_balance,    get_code_size,  get_code_hash,
-    copy_code,      selfdestruct, call,        get_tx_context, get_block_hash, evm_log,
+    copy_code,      selfdestruct, call,        get_tx_context, get_block_hash, emit_log,
 };
 
 /// Example how the API is supposed to be used.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -454,13 +454,35 @@ typedef void (*evmc_get_storage_fn)(struct evmc_uint256be* result,
 
 /**
  * The effect of an attempt to modify a contract storage item.
+ *
+ * For the purpose of explaining the meaning of each element, the following
+ * notation is used:
+ * - 0 is zero value,
+ * - X != 0 (X is any value other than 0),
+ * - Y != X, Y != 0 (Y is any value other than X and 0),
+ * - the "->" means the change from one value to another.
  */
 enum evmc_storage_status
 {
-    EVMC_STORAGE_UNCHANGED = 0, /**< The storage item value unchanged. */
-    EVMC_STORAGE_MODIFIED = 1,  /**< The storage item value modified. */
-    EVMC_STORAGE_ADDED = 2,     /**< The storage item added. */
-    EVMC_STORAGE_DELETED = 3,   /**< The storage item deleted. */
+    /**
+     * The value of a storage item has been left unchanged: 0 -> 0 and X -> X.
+     */
+    EVMC_STORAGE_UNCHANGED = 0,
+
+    /**
+     * The value of a storage item has been modified: X -> Y.
+     */
+    EVMC_STORAGE_MODIFIED = 1,
+
+    /**
+     * A new storage item has been added: 0 -> X.
+     */
+    EVMC_STORAGE_ADDED = 2,
+
+    /**
+     * A storage item has been deleted: X -> 0.
+     */
+    EVMC_STORAGE_DELETED = 3,
 };
 
 
@@ -474,7 +496,7 @@ enum evmc_storage_status
  * @param address  The address of the contract.
  * @param key      The index of the storage entry.
  * @param value    The value to be stored.
- * @return         The effect on the storage item.
+ * @return         The effect on the storage item, @see ::evmc_storage_status.
  */
 typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
                                                         const struct evmc_address* address,

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -40,7 +40,7 @@ extern "C" {
 enum
 {
     /** The EVMC ABI version number of the interface declared in this file. */
-    EVMC_ABI_VERSION = 4
+    EVMC_ABI_VERSION = 5
 };
 
 /**
@@ -451,21 +451,35 @@ typedef void (*evmc_get_storage_fn)(struct evmc_uint256be* result,
                                     const struct evmc_address* address,
                                     const struct evmc_uint256be* key);
 
+
+/**
+ * The effect of an attempt to modify a contract storage item.
+ */
+enum evmc_storage_status
+{
+    EVMC_STORAGE_UNCHANGED = 0, /**< The storage item value unchanged. */
+    EVMC_STORAGE_MODIFIED = 1,  /**< The storage item value modified. */
+    EVMC_STORAGE_ADDED = 2,     /**< The storage item added. */
+    EVMC_STORAGE_DELETED = 3,   /**< The storage item deleted. */
+};
+
+
 /**
  * Set storage callback function.
  *
- *  This callback function is used by an EVM to update the given contract
- *  storage entry.
- *  @param context  The pointer to the Host execution context.
- *                  @see ::evmc_context.
- *  @param address  The address of the contract.
- *  @param key      The index of the storage entry.
- *  @param value    The value to be stored.
+ * This callback function is used by an EVM to update the given contract
+ * storage entry.
+ * @param context  The pointer to the Host execution context.
+ *                 @see ::evmc_context.
+ * @param address  The address of the contract.
+ * @param key      The index of the storage entry.
+ * @param value    The value to be stored.
+ * @return         The effect on the storage item.
  */
-typedef void (*evmc_set_storage_fn)(struct evmc_context* context,
-                                    const struct evmc_address* address,
-                                    const struct evmc_uint256be* key,
-                                    const struct evmc_uint256be* value);
+typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
+                                                        const struct evmc_address* address,
+                                                        const struct evmc_uint256be* key,
+                                                        const struct evmc_uint256be* value);
 
 /**
  * Get balance callback function.


### PR DESCRIPTION
Extend set_storage() by reporting the storage status.

Surprisingly, this was quite easy and aleth-interpreter is simpler and works without any test failure. 