### PR TITLE
AppVeyor fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ before_build:
     if ($env:GENERATOR) {
       if (!(test-path build)) { mkdir build }
       cd build
-      cmake -G "$env:GENERATOR" .. -DBUILD_SHARED_LIBS=ON -DEVMC_EXAMPLES=ON -DEVMC_TESTING=ON -DCMAKE_INSTALL_PREFIX=C:\install
+      cmake -Wno-dev -G "$env:GENERATOR" .. -DBUILD_SHARED_LIBS=ON -DEVMC_EXAMPLES=ON -DEVMC_TESTING=ON -DCMAKE_INSTALL_PREFIX=C:\install
     }
 
 build_script:

--- a/cmake/HunterConfig.cmake
+++ b/cmake/HunterConfig.cmake
@@ -6,6 +6,6 @@
 # Hunter is going to be initialized only if building with tests,
 # where it is needed to get dependencies.
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.22.23.tar.gz"
-    SHA1 "16c562a69489ff9c1b5266a12d5e903084de693a"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.4.tar.gz"
+    SHA1 "8b2255921208517a55c9533c500131387e3c3dd0"
 )

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -16,7 +16,7 @@
 #define DLL_HANDLE HMODULE
 #define DLL_OPEN(filename) LoadLibrary(filename)
 #define DLL_CLOSE(handle) FreeLibrary(handle)
-#define DLL_GET_CREATE_FN(handle, name) (evmc_create_fn) GetProcAddress(handle, name)
+#define DLL_GET_CREATE_FN(handle, name) (evmc_create_fn)(uintptr_t) GetProcAddress(handle, name)
 #define HAVE_STRCPY_S 1
 #else
 #include <dlfcn.h>


### PR DESCRIPTION
Two issues with AppVeyor:
- Go has been upgraded to 1.11, this PR fixes #112.
- AppVeyor cache for Hunter stopped working, bump Hunter version to refresh it.
- Disable dev warnings in CMake.