### PR TITLE
Rename uint256be to bytes32

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -34,7 +34,7 @@ extern const struct evmc_host_interface evmc_go_host;
 static struct evmc_result execute_wrapper(struct evmc_instance* instance,
 	int64_t context_index, enum evmc_revision rev,
 	enum evmc_call_kind kind, uint32_t flags, int32_t depth, int64_t gas,
-	const struct evmc_address* destination, const struct evmc_address* sender,
+	const evmc_address* destination, const evmc_address* sender,
 	const uint8_t* input_data, size_t input_size, const evmc_uint256be* value,
 	const uint8_t* code, size_t code_size, const evmc_bytes32* create2_salt)
 {
@@ -70,8 +70,8 @@ import (
 const (
 	_ = uint(common.HashLength - C.sizeof_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
 	_ = uint(C.sizeof_evmc_bytes32 - common.HashLength)
-	_ = uint(common.AddressLength - C.sizeof_struct_evmc_address) // The size of evmc_address equals the size of Address.
-	_ = uint(C.sizeof_struct_evmc_address - common.AddressLength)
+	_ = uint(common.AddressLength - C.sizeof_evmc_address) // The size of evmc_address equals the size of Address.
+	_ = uint(C.sizeof_evmc_address - common.AddressLength)
 )
 
 type Error int32
@@ -269,8 +269,8 @@ func evmcBytes32(in common.Hash) C.evmc_bytes32 {
 	return out
 }
 
-func evmcAddress(address common.Address) C.struct_evmc_address {
-	r := C.struct_evmc_address{}
+func evmcAddress(address common.Address) C.evmc_address {
+	r := C.evmc_address{}
 	for i := 0; i < len(address); i++ {
 		r.bytes[i] = C.uint8_t(address[i])
 	}

--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -36,7 +36,7 @@ static struct evmc_result execute_wrapper(struct evmc_instance* instance,
 	enum evmc_call_kind kind, uint32_t flags, int32_t depth, int64_t gas,
 	const struct evmc_address* destination, const struct evmc_address* sender,
 	const uint8_t* input_data, size_t input_size, const evmc_uint256be* value,
-	const uint8_t* code, size_t code_size, const struct evmc_bytes32* create2_salt)
+	const uint8_t* code, size_t code_size, const evmc_bytes32* create2_salt)
 {
 	struct evmc_message msg = {
 		kind,
@@ -68,8 +68,8 @@ import (
 
 // Static asserts.
 const (
-	_ = uint(common.HashLength - C.sizeof_struct_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
-	_ = uint(C.sizeof_struct_evmc_bytes32 - common.HashLength)
+	_ = uint(common.HashLength - C.sizeof_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
+	_ = uint(C.sizeof_evmc_bytes32 - common.HashLength)
 	_ = uint(common.AddressLength - C.sizeof_struct_evmc_address) // The size of evmc_address equals the size of Address.
 	_ = uint(C.sizeof_struct_evmc_address - common.AddressLength)
 )
@@ -261,8 +261,8 @@ func getHostContext(idx int) HostContext {
 	return ctx
 }
 
-func evmcBytes32(in common.Hash) C.struct_evmc_bytes32 {
-	out := C.struct_evmc_bytes32{}
+func evmcBytes32(in common.Hash) C.evmc_bytes32 {
+	out := C.evmc_bytes32{}
 	for i := 0; i < len(in); i++ {
 		out.bytes[i] = C.uint8_t(in[i])
 	}

--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -35,8 +35,8 @@ static struct evmc_result execute_wrapper(struct evmc_instance* instance,
 	int64_t context_index, enum evmc_revision rev,
 	enum evmc_call_kind kind, uint32_t flags, int32_t depth, int64_t gas,
 	const struct evmc_address* destination, const struct evmc_address* sender,
-	const uint8_t* input_data, size_t input_size, const struct evmc_uint256be* value,
-	const uint8_t* code, size_t code_size, const struct evmc_uint256be* create2_salt)
+	const uint8_t* input_data, size_t input_size, const evmc_uint256be* value,
+	const uint8_t* code, size_t code_size, const struct evmc_bytes32* create2_salt)
 {
 	struct evmc_message msg = {
 		kind,
@@ -68,8 +68,8 @@ import (
 
 // Static asserts.
 const (
-	_ = uint(common.HashLength - C.sizeof_struct_evmc_uint256be) // The size of evmc_uint256be equals the size of Hash.
-	_ = uint(C.sizeof_struct_evmc_uint256be - common.HashLength)
+	_ = uint(common.HashLength - C.sizeof_struct_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
+	_ = uint(C.sizeof_struct_evmc_bytes32 - common.HashLength)
 	_ = uint(common.AddressLength - C.sizeof_struct_evmc_address) // The size of evmc_address equals the size of Address.
 	_ = uint(C.sizeof_struct_evmc_address - common.AddressLength)
 )
@@ -212,8 +212,8 @@ func (instance *Instance) Execute(ctx HostContext, rev Revision,
 	// FIXME: Clarify passing by pointer vs passing by value.
 	evmcDestination := evmcAddress(destination)
 	evmcSender := evmcAddress(sender)
-	evmcValue := evmcUint256be(value)
-	evmcCreate2Salt := evmcUint256be(create2Salt)
+	evmcValue := evmcBytes32(value)
+	evmcCreate2Salt := evmcBytes32(create2Salt)
 	result := C.execute_wrapper(instance.handle, C.int64_t(ctxId), uint32(rev),
 		C.enum_evmc_call_kind(kind), flags, C.int32_t(depth), C.int64_t(gas),
 		&evmcDestination, &evmcSender, bytesPtr(input), C.size_t(len(input)), &evmcValue,
@@ -261,8 +261,8 @@ func getHostContext(idx int) HostContext {
 	return ctx
 }
 
-func evmcUint256be(in common.Hash) C.struct_evmc_uint256be {
-	out := C.struct_evmc_uint256be{}
+func evmcBytes32(in common.Hash) C.struct_evmc_bytes32 {
+	out := C.struct_evmc_bytes32{}
 	for i := 0; i < len(in); i++ {
 		out.bytes[i] = C.uint8_t(in[i])
 	}

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -41,7 +41,8 @@ static inline void go_exported_functions_type_checks()
 {
     struct evmc_context* context = NULL;
     struct evmc_address* address = NULL;
-    struct evmc_uint256be* uint256be = NULL;
+    struct evmc_bytes32* bytes32 = NULL;
+    evmc_uint256be* uint256be = NULL;
     uint8_t* data = NULL;
     size_t size = 0;
     int64_t number = 0;
@@ -61,12 +62,12 @@ static inline void go_exported_functions_type_checks()
     bool_flag = accountExists(context, address);
 
     evmc_get_storage_fn get_storage_fn = NULL;
-    get_storage_fn(uint256be, context, address, uint256be);
-    getStorage(uint256be, context, address, uint256be);
+    get_storage_fn(bytes32, context, address, bytes32);
+    getStorage(bytes32, context, address, bytes32);
 
     evmc_set_storage_fn set_storage_fn = NULL;
-    storage_status = set_storage_fn(context, address, uint256be, uint256be);
-    storage_status = setStorage(context, address, uint256be, uint256be);
+    storage_status = set_storage_fn(context, address, bytes32, bytes32);
+    storage_status = setStorage(context, address, bytes32, bytes32);
 
     evmc_get_balance_fn get_balance_fn = NULL;
     bool_flag = get_balance_fn(uint256be, context, address);
@@ -77,8 +78,8 @@ static inline void go_exported_functions_type_checks()
     bool_flag = getCodeSize(&size, context, address);
 
     evmc_get_code_hash_fn get_code_hash_fn = NULL;
-    bool_flag = get_code_hash_fn(uint256be, context, address);
-    bool_flag = getCodeHash(uint256be, context, address);
+    bool_flag = get_code_hash_fn(bytes32, context, address);
+    bool_flag = getCodeHash(bytes32, context, address);
 
     evmc_copy_code_fn copy_code_fn = NULL;
     size = copy_code_fn(context, address, size, data, size);
@@ -97,10 +98,10 @@ static inline void go_exported_functions_type_checks()
     tx_context = getTxContext(context);
 
     evmc_get_block_hash_fn get_block_hash_fn = NULL;
-    bool_flag = get_block_hash_fn(uint256be, context, number);
-    bool_flag = getBlockHash(uint256be, context, number);
+    bool_flag = get_block_hash_fn(bytes32, context, number);
+    bool_flag = getBlockHash(bytes32, context, number);
 
     evmc_emit_log_fn emit_log_fn = NULL;
-    emit_log_fn(context, address, data, size, uint256be, size);
-    emitLog(context, address, data, size, uint256be, size);
+    emit_log_fn(context, address, data, size, bytes32, size);
+    emitLog(context, address, data, size, bytes32, size);
 }

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -41,7 +41,7 @@ static inline void go_exported_functions_type_checks()
 {
     struct evmc_context* context = NULL;
     struct evmc_address* address = NULL;
-    struct evmc_bytes32* bytes32 = NULL;
+    evmc_bytes32* bytes32 = NULL;
     evmc_uint256be* uint256be = NULL;
     uint8_t* data = NULL;
     size_t size = 0;

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -40,7 +40,7 @@ const struct evmc_host_interface evmc_go_host = {
 static inline void go_exported_functions_type_checks()
 {
     struct evmc_context* context = NULL;
-    struct evmc_address* address = NULL;
+    evmc_address* address = NULL;
     evmc_bytes32* bytes32 = NULL;
     evmc_uint256be* uint256be = NULL;
     uint8_t* data = NULL;

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -46,7 +46,7 @@ const (
 	StorageDeleted       StorageStatus = C.EVMC_STORAGE_DELETED
 )
 
-func goAddress(in C.struct_evmc_address) common.Address {
+func goAddress(in C.evmc_address) common.Address {
 	out := common.Address{}
 	for i := 0; i < len(out); i++ {
 		out[i] = byte(in.bytes[i])
@@ -88,14 +88,14 @@ type HostContext interface {
 }
 
 //export accountExists
-func accountExists(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func accountExists(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	return C.bool(ctx.AccountExists(goAddress(*pAddr)))
 }
 
 //export getStorage
-func getStorage(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32) C.bool {
+func getStorage(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	value, err := ctx.GetStorage(goAddress(*pAddr), goHash(*pKey))
@@ -107,7 +107,7 @@ func getStorage(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_ev
 }
 
 //export setStorage
-func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
+func setStorage(pCtx unsafe.Pointer, pAddr *C.evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	status, err := ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal))
@@ -118,7 +118,7 @@ func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_
 }
 
 //export getBalance
-func getBalance(pResult *C.evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getBalance(pResult *C.evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	balance, err := ctx.GetBalance(goAddress(*pAddr))
@@ -130,7 +130,7 @@ func getBalance(pResult *C.evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_
 }
 
 //export getCodeSize
-func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	codeSize, err := ctx.GetCodeSize(goAddress(*pAddr))
@@ -142,7 +142,7 @@ func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.struct_evmc_ad
 }
 
 //export getCodeHash
-func getCodeHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getCodeHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	codeHash, err := ctx.GetCodeHash(goAddress(*pAddr))
@@ -154,7 +154,7 @@ func getCodeHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_e
 }
 
 //export copyCode
-func copyCode(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, offset C.size_t, p *C.uint8_t, size C.size_t) C.size_t {
+func copyCode(pCtx unsafe.Pointer, pAddr *C.evmc_address, offset C.size_t, p *C.uint8_t, size C.size_t) C.size_t {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	code := ctx.GetCode(goAddress(*pAddr))
@@ -175,7 +175,7 @@ func copyCode(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, offset C.size_t
 }
 
 //export selfdestruct
-func selfdestruct(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pBeneficiary *C.struct_evmc_address) {
+func selfdestruct(pCtx unsafe.Pointer, pAddr *C.evmc_address, pBeneficiary *C.evmc_address) {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	ctx.Selfdestruct(goAddress(*pAddr), goAddress(*pBeneficiary))
@@ -214,7 +214,7 @@ func getBlockHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, number int64) C.
 }
 
 //export emitLog
-func emitLog(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pData unsafe.Pointer, dataSize C.size_t, pTopics unsafe.Pointer, topicsCount C.size_t) {
+func emitLog(pCtx unsafe.Pointer, pAddr *C.evmc_address, pData unsafe.Pointer, dataSize C.size_t, pTopics unsafe.Pointer, topicsCount C.size_t) {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -54,7 +54,7 @@ func goAddress(in C.struct_evmc_address) common.Address {
 	return out
 }
 
-func goHash(in C.struct_evmc_bytes32) common.Hash {
+func goHash(in C.evmc_bytes32) common.Hash {
 	out := common.Hash{}
 	for i := 0; i < len(out); i++ {
 		out[i] = byte(in.bytes[i])
@@ -95,7 +95,7 @@ func accountExists(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
 }
 
 //export getStorage
-func getStorage(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32) C.bool {
+func getStorage(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	value, err := ctx.GetStorage(goAddress(*pAddr), goHash(*pKey))
@@ -107,7 +107,7 @@ func getStorage(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.st
 }
 
 //export setStorage
-func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32, pVal *C.struct_evmc_bytes32) C.enum_evmc_storage_status {
+func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	status, err := ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal))
@@ -142,7 +142,7 @@ func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.struct_evmc_ad
 }
 
 //export getCodeHash
-func getCodeHash(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getCodeHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	codeHash, err := ctx.GetCodeHash(goAddress(*pAddr))
@@ -200,7 +200,7 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 }
 
 //export getBlockHash
-func getBlockHash(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, number int64) C.bool {
+func getBlockHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, number int64) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -54,7 +54,7 @@ func goAddress(in C.struct_evmc_address) common.Address {
 	return out
 }
 
-func goHash(in C.struct_evmc_uint256be) common.Hash {
+func goHash(in C.struct_evmc_bytes32) common.Hash {
 	out := common.Hash{}
 	for i := 0; i < len(out); i++ {
 		out[i] = byte(in.bytes[i])
@@ -95,19 +95,19 @@ func accountExists(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
 }
 
 //export getStorage
-func getStorage(pResult *C.struct_evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_uint256be) C.bool {
+func getStorage(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	value, err := ctx.GetStorage(goAddress(*pAddr), goHash(*pKey))
 	if err != nil {
 		return false
 	}
-	*pResult = evmcUint256be(value)
+	*pResult = evmcBytes32(value)
 	return true
 }
 
 //export setStorage
-func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_uint256be, pVal *C.struct_evmc_uint256be) C.enum_evmc_storage_status {
+func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struct_evmc_bytes32, pVal *C.struct_evmc_bytes32) C.enum_evmc_storage_status {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	status, err := ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal))
@@ -118,14 +118,14 @@ func setStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.struc
 }
 
 //export getBalance
-func getBalance(pResult *C.struct_evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getBalance(pResult *C.evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	balance, err := ctx.GetBalance(goAddress(*pAddr))
 	if err != nil {
 		return false
 	}
-	*pResult = evmcUint256be(balance)
+	*pResult = evmcBytes32(balance)
 	return true
 }
 
@@ -142,14 +142,14 @@ func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.struct_evmc_ad
 }
 
 //export getCodeHash
-func getCodeHash(pResult *C.struct_evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
+func getCodeHash(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 	codeHash, err := ctx.GetCodeHash(goAddress(*pAddr))
 	if err != nil {
 		return false
 	}
-	*pResult = evmcUint256be(codeHash)
+	*pResult = evmcBytes32(codeHash)
 	return true
 }
 
@@ -189,18 +189,18 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 	gasPrice, origin, coinbase, number, timestamp, gasLimit, difficulty := ctx.GetTxContext()
 
 	return C.struct_evmc_tx_context{
-		evmcUint256be(gasPrice),
+		evmcBytes32(gasPrice),
 		evmcAddress(origin),
 		evmcAddress(coinbase),
 		C.int64_t(number),
 		C.int64_t(timestamp),
 		C.int64_t(gasLimit),
-		evmcUint256be(difficulty),
+		evmcBytes32(difficulty),
 	}
 }
 
 //export getBlockHash
-func getBlockHash(pResult *C.struct_evmc_uint256be, pCtx unsafe.Pointer, number int64) C.bool {
+func getBlockHash(pResult *C.struct_evmc_bytes32, pCtx unsafe.Pointer, number int64) C.bool {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
 
@@ -209,7 +209,7 @@ func getBlockHash(pResult *C.struct_evmc_uint256be, pCtx unsafe.Pointer, number 
 		return false
 	}
 
-	*pResult = evmcUint256be(blockhash)
+	*pResult = evmcBytes32(blockhash)
 	return true
 }
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -20,7 +20,7 @@ int main()
     const uint8_t code[] = "\x30\x60\x00\x52\x59\x60\x00\xf3";
     const size_t code_size = sizeof(code);
     const uint8_t input[] = "Hello World!";
-    const struct evmc_uint256be value = {{1, 0}};
+    const evmc_uint256be value = {{1, 0}};
     const struct evmc_address addr = {{0, 1, 2}};
     const int64_t gas = 200000;
     struct evmc_context* ctx = example_host_create_context();

--- a/examples/example.c
+++ b/examples/example.c
@@ -21,7 +21,7 @@ int main()
     const size_t code_size = sizeof(code);
     const uint8_t input[] = "Hello World!";
     const evmc_uint256be value = {{1, 0}};
-    const struct evmc_address addr = {{0, 1, 2}};
+    const evmc_address addr = {{0, 1, 2}};
     const int64_t gas = 200000;
     struct evmc_context* ctx = example_host_create_context();
     struct evmc_message msg;

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -18,13 +18,13 @@ bool operator<(const evmc_address& a, const evmc_address& b)
     return std::memcmp(a.bytes, b.bytes, sizeof(a)) < 0;
 }
 
-/// The comparator for std::map<evmc_uint256be, ...>.
-bool operator<(const evmc_uint256be& a, const evmc_uint256be& b)
+/// The comparator for std::map<evmc_bytes32, ...>.
+bool operator<(const evmc_bytes32& a, const evmc_bytes32& b)
 {
     return std::memcmp(a.bytes, b.bytes, sizeof(a)) < 0;
 }
 
-bool operator==(const evmc_uint256be& a, const evmc_uint256be& b)
+bool operator==(const evmc_bytes32& a, const evmc_bytes32& b)
 {
     return std::memcmp(a.bytes, b.bytes, sizeof(a)) == 0;
 }
@@ -33,8 +33,8 @@ struct account
 {
     evmc_uint256be balance = {};
     size_t code_size = 0;
-    evmc_uint256be code_hash = {};
-    std::map<evmc_uint256be, evmc_uint256be> storage;
+    evmc_bytes32 code_hash = {};
+    std::map<evmc_bytes32, evmc_bytes32> storage;
 };
 
 struct example_host_context : evmc_context
@@ -52,10 +52,10 @@ static bool account_exists(evmc_context* context, const evmc_address* address)
     return host->accounts.find(*address) != host->accounts.end();
 }
 
-static bool get_storage(evmc_uint256be* result,
+static bool get_storage(evmc_bytes32* result,
                         evmc_context* context,
                         const evmc_address* address,
-                        const evmc_uint256be* key)
+                        const evmc_bytes32* key)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
@@ -69,8 +69,8 @@ static bool get_storage(evmc_uint256be* result,
 
 static enum evmc_storage_status set_storage(evmc_context* context,
                                             const evmc_address* address,
-                                            const evmc_uint256be* key,
-                                            const evmc_uint256be* value)
+                                            const evmc_bytes32* key,
+                                            const evmc_bytes32* value)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto accountIt = host->accounts.find(*address);
@@ -118,9 +118,7 @@ static bool get_code_size(size_t* result, evmc_context* context, const evmc_addr
     return false;
 }
 
-static bool get_code_hash(evmc_uint256be* result,
-                          evmc_context* context,
-                          const evmc_address* address)
+static bool get_code_hash(evmc_bytes32* result, evmc_context* context, const evmc_address* address)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
@@ -171,7 +169,7 @@ static evmc_tx_context get_tx_context(evmc_context* context)
     return result;
 }
 
-static bool get_block_hash(evmc_uint256be* result, evmc_context* context, int64_t number)
+static bool get_block_hash(evmc_bytes32* result, evmc_context* context, int64_t number)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     int64_t current_block_number = host->tx_context.block_number;
@@ -179,7 +177,7 @@ static bool get_block_hash(evmc_uint256be* result, evmc_context* context, int64_
     if (number >= current_block_number || number < current_block_number - 256)
         return false;
 
-    evmc_uint256be example_block_hash{};
+    evmc_bytes32 example_block_hash{};
     *result = example_block_hash;
     return true;
 }
@@ -188,7 +186,7 @@ static void emit_log(evmc_context* context,
                      const evmc_address* address,
                      const uint8_t* data,
                      size_t data_size,
-                     const evmc_uint256be topics[],
+                     const evmc_bytes32 topics[],
                      size_t topics_count)
 {
     (void)context;

--- a/examples/example_vm.c
+++ b/examples/example_vm.c
@@ -114,11 +114,11 @@ static struct evmc_result execute(struct evmc_instance* instance,
     }
     else if (code_size == strlen(counter) && strncmp((const char*)code, counter, code_size) == 0)
     {
-        struct evmc_uint256be value;
-        const struct evmc_uint256be index = {{0}};
-        context->host->get_storage(&value, context, &msg->destination, &index);
+        struct evmc_bytes32 value;
+        const struct evmc_bytes32 key = {{0}};
+        context->host->get_storage(&value, context, &msg->destination, &key);
         value.bytes[31]++;
-        context->host->set_storage(context, &msg->destination, &index, &value);
+        context->host->set_storage(context, &msg->destination, &key, &value);
         ret.status_code = EVMC_SUCCESS;
         return ret;
     }

--- a/examples/example_vm.c
+++ b/examples/example_vm.c
@@ -114,8 +114,8 @@ static struct evmc_result execute(struct evmc_instance* instance,
     }
     else if (code_size == strlen(counter) && strncmp((const char*)code, counter, code_size) == 0)
     {
-        struct evmc_bytes32 value;
-        const struct evmc_bytes32 key = {{0}};
+        evmc_bytes32 value;
+        const evmc_bytes32 key = {{0}};
         context->host->get_storage(&value, context, &msg->destination, &key);
         value.bytes[31]++;
         context->host->set_storage(context, &msg->destination, &key, &value);

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -34,19 +34,22 @@ enum
     EVMC_ABI_VERSION = 6
 };
 
+
 /**
- * Big-endian 256-bit integer.
+ * The fixed size array of 32 bytes.
  *
- * 32 bytes of data representing big-endian 256-bit integer. I.e. bytes[0] is
- * the most significant byte, bytes[31] is the least significant byte.
- * This type is used to transfer to/from the VM values interpreted by the user
- * as both 256-bit integers and 256-bit hashes.
+ * 32 bytes of data capable of storing e.g. 256-bit hashes.
  */
-struct evmc_uint256be
+struct evmc_bytes32
 {
-    /** The 32 bytes of the big-endian integer or hash. */
+    /** The 32 bytes. */
     uint8_t bytes[32];
 };
+
+/**
+ * The alias for evmc_bytes32 to represent a big-endian 256-bit integer.
+ */
+typedef struct evmc_bytes32 evmc_uint256be;
 
 /** Big-endian 160-bit hash suitable for keeping an Ethereum address. */
 struct evmc_address
@@ -116,27 +119,27 @@ struct evmc_message
     /**
      * The amount of Ether transferred with the message.
      */
-    struct evmc_uint256be value;
+    evmc_uint256be value;
 
     /**
      * The optional value used in new contract address construction.
      *
      * Ignored unless kind is EVMC_CREATE2.
      */
-    struct evmc_uint256be create2_salt;
+    struct evmc_bytes32 create2_salt;
 };
 
 
 /** The transaction and block data for execution. */
 struct evmc_tx_context
 {
-    struct evmc_uint256be tx_gas_price;     /**< The transaction gas price. */
-    struct evmc_address tx_origin;          /**< The transaction origin account. */
-    struct evmc_address block_coinbase;     /**< The miner of the block. */
-    int64_t block_number;                   /**< The block number. */
-    int64_t block_timestamp;                /**< The block timestamp. */
-    int64_t block_gas_limit;                /**< The block gas limit. */
-    struct evmc_uint256be block_difficulty; /**< The block difficulty. */
+    evmc_uint256be tx_gas_price;        /**< The transaction gas price. */
+    struct evmc_address tx_origin;      /**< The transaction origin account. */
+    struct evmc_address block_coinbase; /**< The miner of the block. */
+    int64_t block_number;               /**< The block number. */
+    int64_t block_timestamp;            /**< The block timestamp. */
+    int64_t block_gas_limit;            /**< The block gas limit. */
+    evmc_uint256be block_difficulty;    /**< The block difficulty. */
 };
 
 struct evmc_context;
@@ -165,7 +168,7 @@ typedef struct evmc_tx_context (*evmc_get_tx_context_fn)(struct evmc_context* co
  * @param      number   The block number.
  * @return              true if the information is available, false otherwise.
  */
-typedef bool (*evmc_get_block_hash_fn)(struct evmc_uint256be* result,
+typedef bool (*evmc_get_block_hash_fn)(struct evmc_bytes32* result,
                                        struct evmc_context* context,
                                        int64_t number);
 
@@ -420,10 +423,10 @@ typedef bool (*evmc_account_exists_fn)(struct evmc_context* context,
  *                      If the account does not exist false is returned without
  *                      modifying the memory pointed by @p result.
  */
-typedef bool (*evmc_get_storage_fn)(struct evmc_uint256be* result,
+typedef bool (*evmc_get_storage_fn)(struct evmc_bytes32* result,
                                     struct evmc_context* context,
                                     const struct evmc_address* address,
-                                    const struct evmc_uint256be* key);
+                                    const struct evmc_bytes32* key);
 
 
 /**
@@ -484,8 +487,8 @@ enum evmc_storage_status
  */
 typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
                                                         const struct evmc_address* address,
-                                                        const struct evmc_uint256be* key,
-                                                        const struct evmc_uint256be* value);
+                                                        const struct evmc_bytes32* key,
+                                                        const struct evmc_bytes32* value);
 
 /**
  * Get balance callback function.
@@ -502,7 +505,7 @@ typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* con
  *                      If the account does not exist false is returned without
  *                      modifying the memory pointed by @p result.
  */
-typedef bool (*evmc_get_balance_fn)(struct evmc_uint256be* result,
+typedef bool (*evmc_get_balance_fn)(evmc_uint256be* result,
                                     struct evmc_context* context,
                                     const struct evmc_address* address);
 
@@ -543,7 +546,7 @@ typedef bool (*evmc_get_code_size_fn)(size_t* result,
  *                      If the account does not exist false is returned without
  *                      modifying the memory pointed by @p result.
  */
-typedef bool (*evmc_get_code_hash_fn)(struct evmc_uint256be* result,
+typedef bool (*evmc_get_code_hash_fn)(struct evmc_bytes32* result,
                                       struct evmc_context* context,
                                       const struct evmc_address* address);
 
@@ -605,7 +608,7 @@ typedef void (*evmc_emit_log_fn)(struct evmc_context* context,
                                  const struct evmc_address* address,
                                  const uint8_t* data,
                                  size_t data_size,
-                                 const struct evmc_uint256be topics[],
+                                 const struct evmc_bytes32 topics[],
                                  size_t topics_count);
 
 /**
@@ -806,7 +809,7 @@ typedef void (*evmc_trace_callback)(struct evmc_tracer_context* context,
                                     enum evmc_status_code status_code,
                                     int64_t gas_left,
                                     size_t stack_num_items,
-                                    const struct evmc_uint256be* pushed_stack_item,
+                                    const evmc_uint256be* pushed_stack_item,
                                     size_t memory_size,
                                     size_t changed_memory_offset,
                                     size_t changed_memory_size,

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -52,11 +52,11 @@ typedef struct evmc_bytes32
 typedef struct evmc_bytes32 evmc_uint256be;
 
 /** Big-endian 160-bit hash suitable for keeping an Ethereum address. */
-struct evmc_address
+typedef struct evmc_address
 {
     /** The 20 bytes of the hash. */
     uint8_t bytes[20];
-};
+} evmc_address;
 
 /** The kind of call-like instruction. */
 enum evmc_call_kind
@@ -97,10 +97,10 @@ struct evmc_message
     int64_t gas;
 
     /** The destination of the message. */
-    struct evmc_address destination;
+    evmc_address destination;
 
     /** The sender of the message. */
-    struct evmc_address sender;
+    evmc_address sender;
 
     /**
      * The message input data.
@@ -133,13 +133,13 @@ struct evmc_message
 /** The transaction and block data for execution. */
 struct evmc_tx_context
 {
-    evmc_uint256be tx_gas_price;        /**< The transaction gas price. */
-    struct evmc_address tx_origin;      /**< The transaction origin account. */
-    struct evmc_address block_coinbase; /**< The miner of the block. */
-    int64_t block_number;               /**< The block number. */
-    int64_t block_timestamp;            /**< The block timestamp. */
-    int64_t block_gas_limit;            /**< The block gas limit. */
-    evmc_uint256be block_difficulty;    /**< The block difficulty. */
+    evmc_uint256be tx_gas_price;     /**< The transaction gas price. */
+    evmc_address tx_origin;          /**< The transaction origin account. */
+    evmc_address block_coinbase;     /**< The miner of the block. */
+    int64_t block_number;            /**< The block number. */
+    int64_t block_timestamp;         /**< The block timestamp. */
+    int64_t block_gas_limit;         /**< The block gas limit. */
+    evmc_uint256be block_difficulty; /**< The block difficulty. */
 };
 
 struct evmc_context;
@@ -380,7 +380,7 @@ struct evmc_result
      *  This field has valid value only if the result describes successful
      *  CREATE (evmc_result::status_code is ::EVMC_SUCCESS).
      */
-    struct evmc_address create_address;
+    evmc_address create_address;
 
     /**
      * Reserved data that MAY be used by a evmc_result object creator.
@@ -406,8 +406,7 @@ struct evmc_result
  * @param address  The address of the account the query is about.
  * @return         true if exists, false otherwise.
  */
-typedef bool (*evmc_account_exists_fn)(struct evmc_context* context,
-                                       const struct evmc_address* address);
+typedef bool (*evmc_account_exists_fn)(struct evmc_context* context, const evmc_address* address);
 
 /**
  * Get storage callback function.
@@ -425,7 +424,7 @@ typedef bool (*evmc_account_exists_fn)(struct evmc_context* context,
  */
 typedef bool (*evmc_get_storage_fn)(evmc_bytes32* result,
                                     struct evmc_context* context,
-                                    const struct evmc_address* address,
+                                    const evmc_address* address,
                                     const evmc_bytes32* key);
 
 
@@ -486,7 +485,7 @@ enum evmc_storage_status
  * @return         The effect on the storage item. @see ::evmc_storage_status.
  */
 typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
-                                                        const struct evmc_address* address,
+                                                        const evmc_address* address,
                                                         const evmc_bytes32* key,
                                                         const evmc_bytes32* value);
 
@@ -507,7 +506,7 @@ typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* con
  */
 typedef bool (*evmc_get_balance_fn)(evmc_uint256be* result,
                                     struct evmc_context* context,
-                                    const struct evmc_address* address);
+                                    const evmc_address* address);
 
 /**
  * Get code size callback function.
@@ -527,7 +526,7 @@ typedef bool (*evmc_get_balance_fn)(evmc_uint256be* result,
  */
 typedef bool (*evmc_get_code_size_fn)(size_t* result,
                                       struct evmc_context* context,
-                                      const struct evmc_address* address);
+                                      const evmc_address* address);
 
 /**
  * Get code size callback function.
@@ -548,7 +547,7 @@ typedef bool (*evmc_get_code_size_fn)(size_t* result,
  */
 typedef bool (*evmc_get_code_hash_fn)(evmc_bytes32* result,
                                       struct evmc_context* context,
-                                      const struct evmc_address* address);
+                                      const evmc_address* address);
 
 /**
  * Copy code callback function.
@@ -569,7 +568,7 @@ typedef bool (*evmc_get_code_hash_fn)(evmc_bytes32* result,
  *  @return             The number of bytes copied to the buffer by the Client.
  */
 typedef size_t (*evmc_copy_code_fn)(struct evmc_context* context,
-                                    const struct evmc_address* address,
+                                    const evmc_address* address,
                                     size_t code_offset,
                                     uint8_t* buffer_data,
                                     size_t buffer_size);
@@ -587,8 +586,8 @@ typedef size_t (*evmc_copy_code_fn)(struct evmc_context* context,
  *                      transferred.
  */
 typedef void (*evmc_selfdestruct_fn)(struct evmc_context* context,
-                                     const struct evmc_address* address,
-                                     const struct evmc_address* beneficiary);
+                                     const evmc_address* address,
+                                     const evmc_address* beneficiary);
 
 /**
  * Log callback function.
@@ -605,7 +604,7 @@ typedef void (*evmc_selfdestruct_fn)(struct evmc_context* context,
  *                       0 and 4 inclusively.
  */
 typedef void (*evmc_emit_log_fn)(struct evmc_context* context,
-                                 const struct evmc_address* address,
+                                 const evmc_address* address,
                                  const uint8_t* data,
                                  size_t data_size,
                                  const evmc_bytes32 topics[],

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -40,11 +40,11 @@ enum
  *
  * 32 bytes of data capable of storing e.g. 256-bit hashes.
  */
-struct evmc_bytes32
+typedef struct evmc_bytes32
 {
     /** The 32 bytes. */
     uint8_t bytes[32];
-};
+} evmc_bytes32;
 
 /**
  * The alias for evmc_bytes32 to represent a big-endian 256-bit integer.
@@ -126,7 +126,7 @@ struct evmc_message
      *
      * Ignored unless kind is EVMC_CREATE2.
      */
-    struct evmc_bytes32 create2_salt;
+    evmc_bytes32 create2_salt;
 };
 
 
@@ -168,7 +168,7 @@ typedef struct evmc_tx_context (*evmc_get_tx_context_fn)(struct evmc_context* co
  * @param      number   The block number.
  * @return              true if the information is available, false otherwise.
  */
-typedef bool (*evmc_get_block_hash_fn)(struct evmc_bytes32* result,
+typedef bool (*evmc_get_block_hash_fn)(evmc_bytes32* result,
                                        struct evmc_context* context,
                                        int64_t number);
 
@@ -423,10 +423,10 @@ typedef bool (*evmc_account_exists_fn)(struct evmc_context* context,
  *                      If the account does not exist false is returned without
  *                      modifying the memory pointed by @p result.
  */
-typedef bool (*evmc_get_storage_fn)(struct evmc_bytes32* result,
+typedef bool (*evmc_get_storage_fn)(evmc_bytes32* result,
                                     struct evmc_context* context,
                                     const struct evmc_address* address,
-                                    const struct evmc_bytes32* key);
+                                    const evmc_bytes32* key);
 
 
 /**
@@ -487,8 +487,8 @@ enum evmc_storage_status
  */
 typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
                                                         const struct evmc_address* address,
-                                                        const struct evmc_bytes32* key,
-                                                        const struct evmc_bytes32* value);
+                                                        const evmc_bytes32* key,
+                                                        const evmc_bytes32* value);
 
 /**
  * Get balance callback function.
@@ -546,7 +546,7 @@ typedef bool (*evmc_get_code_size_fn)(size_t* result,
  *                      If the account does not exist false is returned without
  *                      modifying the memory pointed by @p result.
  */
-typedef bool (*evmc_get_code_hash_fn)(struct evmc_bytes32* result,
+typedef bool (*evmc_get_code_hash_fn)(evmc_bytes32* result,
                                       struct evmc_context* context,
                                       const struct evmc_address* address);
 
@@ -608,7 +608,7 @@ typedef void (*evmc_emit_log_fn)(struct evmc_context* context,
                                  const struct evmc_address* address,
                                  const uint8_t* data,
                                  size_t data_size,
-                                 const struct evmc_bytes32 topics[],
+                                 const evmc_bytes32 topics[],
                                  size_t topics_count);
 
 /**

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -12,7 +12,7 @@
 
 // Compile time checks:
 
-static_assert(sizeof(evmc_uint256be) == 32, "evmc_uint256be is too big");
+static_assert(sizeof(evmc_bytes32) == 32, "evmc_bytes32 is too big");
 static_assert(sizeof(evmc_address) == 20, "evmc_address is too big");
 static_assert(sizeof(evmc_result) <= 64, "evmc_result does not fit cache line");
 static_assert(sizeof(evmc_instance) <= 64, "evmc_instance does not fit cache line");


### PR DESCRIPTION
Closes #121 

Some things to consider
- Add alias `evmc_hash256` for explicit crypto-hashes.
- Add alias `evmc_bytes32` and `evmc_address` to avoid `struct` prefix.