### PR TITLE
Simplify signatures of Host methods

### DIFF
--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -79,8 +79,8 @@ static inline void go_exported_functions_type_checks()
     size = getCodeSize(context, address);
 
     evmc_get_code_hash_fn get_code_hash_fn = NULL;
-    bool_flag = get_code_hash_fn(&bytes32, context, address);
-    bool_flag = getCodeHash(&bytes32, context, address);
+    bytes32 = get_code_hash_fn(context, address);
+    bytes32 = getCodeHash(context, address);
 
     evmc_copy_code_fn copy_code_fn = NULL;
     size = copy_code_fn(context, address, size, data, size);

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -42,12 +42,13 @@ static inline void go_exported_functions_type_checks()
     struct evmc_context* context = NULL;
     evmc_address* address = NULL;
     evmc_bytes32 bytes32;
-    evmc_uint256be* uint256be = NULL;
     uint8_t* data = NULL;
     size_t size = 0;
     int64_t number = 0;
     struct evmc_message* message = NULL;
 
+    evmc_uint256be uint256be;
+    (void)uint256be;
     struct evmc_tx_context tx_context;
     (void)tx_context;
     struct evmc_result result;
@@ -70,8 +71,8 @@ static inline void go_exported_functions_type_checks()
     storage_status = setStorage(context, address, &bytes32, &bytes32);
 
     evmc_get_balance_fn get_balance_fn = NULL;
-    bool_flag = get_balance_fn(uint256be, context, address);
-    bool_flag = getBalance(uint256be, context, address);
+    uint256be = get_balance_fn(context, address);
+    uint256be = getBalance(context, address);
 
     evmc_get_code_size_fn get_code_size_fn = NULL;
     bool_flag = get_code_size_fn(&size, context, address);

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -41,7 +41,7 @@ static inline void go_exported_functions_type_checks()
 {
     struct evmc_context* context = NULL;
     evmc_address* address = NULL;
-    evmc_bytes32* bytes32 = NULL;
+    evmc_bytes32 bytes32;
     evmc_uint256be* uint256be = NULL;
     uint8_t* data = NULL;
     size_t size = 0;
@@ -62,12 +62,12 @@ static inline void go_exported_functions_type_checks()
     bool_flag = accountExists(context, address);
 
     evmc_get_storage_fn get_storage_fn = NULL;
-    get_storage_fn(bytes32, context, address, bytes32);
-    getStorage(bytes32, context, address, bytes32);
+    bytes32 = get_storage_fn(context, address, &bytes32);
+    bytes32 = getStorage(context, address, &bytes32);
 
     evmc_set_storage_fn set_storage_fn = NULL;
-    storage_status = set_storage_fn(context, address, bytes32, bytes32);
-    storage_status = setStorage(context, address, bytes32, bytes32);
+    storage_status = set_storage_fn(context, address, &bytes32, &bytes32);
+    storage_status = setStorage(context, address, &bytes32, &bytes32);
 
     evmc_get_balance_fn get_balance_fn = NULL;
     bool_flag = get_balance_fn(uint256be, context, address);
@@ -78,8 +78,8 @@ static inline void go_exported_functions_type_checks()
     bool_flag = getCodeSize(&size, context, address);
 
     evmc_get_code_hash_fn get_code_hash_fn = NULL;
-    bool_flag = get_code_hash_fn(bytes32, context, address);
-    bool_flag = getCodeHash(bytes32, context, address);
+    bool_flag = get_code_hash_fn(&bytes32, context, address);
+    bool_flag = getCodeHash(&bytes32, context, address);
 
     evmc_copy_code_fn copy_code_fn = NULL;
     size = copy_code_fn(context, address, size, data, size);
@@ -98,10 +98,10 @@ static inline void go_exported_functions_type_checks()
     tx_context = getTxContext(context);
 
     evmc_get_block_hash_fn get_block_hash_fn = NULL;
-    bool_flag = get_block_hash_fn(bytes32, context, number);
-    bool_flag = getBlockHash(bytes32, context, number);
+    bool_flag = get_block_hash_fn(&bytes32, context, number);
+    bool_flag = getBlockHash(&bytes32, context, number);
 
     evmc_emit_log_fn emit_log_fn = NULL;
-    emit_log_fn(context, address, data, size, bytes32, size);
-    emitLog(context, address, data, size, bytes32, size);
+    emit_log_fn(context, address, data, size, &bytes32, size);
+    emitLog(context, address, data, size, &bytes32, size);
 }

--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -75,8 +75,8 @@ static inline void go_exported_functions_type_checks()
     uint256be = getBalance(context, address);
 
     evmc_get_code_size_fn get_code_size_fn = NULL;
-    bool_flag = get_code_size_fn(&size, context, address);
-    bool_flag = getCodeSize(&size, context, address);
+    size = get_code_size_fn(context, address);
+    size = getCodeSize(context, address);
 
     evmc_get_code_hash_fn get_code_hash_fn = NULL;
     bool_flag = get_code_hash_fn(&bytes32, context, address);

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -74,7 +74,7 @@ type HostContext interface {
 	GetStorage(addr common.Address, key common.Hash) common.Hash
 	SetStorage(addr common.Address, key common.Hash, value common.Hash) StorageStatus
 	GetBalance(addr common.Address) common.Hash
-	GetCodeSize(addr common.Address) (int, error)
+	GetCodeSize(addr common.Address) int
 	GetCodeHash(addr common.Address) (common.Hash, error)
 	GetCode(addr common.Address) []byte
 	Selfdestruct(addr common.Address, beneficiary common.Address)
@@ -116,15 +116,10 @@ func getBalance(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.evmc_uint256be {
 }
 
 //export getCodeSize
-func getCodeSize(pResult *C.size_t, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
+func getCodeSize(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.size_t {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	codeSize, err := ctx.GetCodeSize(goAddress(*pAddr))
-	if err != nil {
-		return false
-	}
-	*pResult = C.size_t(codeSize)
-	return true
+	return C.size_t(ctx.GetCodeSize(goAddress(*pAddr)))
 }
 
 //export getCodeHash

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -72,7 +72,7 @@ func goByteSlice(data *C.uint8_t, size C.size_t) []byte {
 type HostContext interface {
 	AccountExists(addr common.Address) bool
 	GetStorage(addr common.Address, key common.Hash) common.Hash
-	SetStorage(addr common.Address, key common.Hash, value common.Hash) (StorageStatus, error)
+	SetStorage(addr common.Address, key common.Hash, value common.Hash) StorageStatus
 	GetBalance(addr common.Address) (common.Hash, error)
 	GetCodeSize(addr common.Address) (int, error)
 	GetCodeHash(addr common.Address) (common.Hash, error)
@@ -105,11 +105,7 @@ func getStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_
 func setStorage(pCtx unsafe.Pointer, pAddr *C.evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	status, err := ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal))
-	if err != nil {
-		return C.EVMC_STORAGE_NON_EXISTING_ACCOUNT
-	}
-	return C.enum_evmc_storage_status(status)
+	return C.enum_evmc_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)));
 }
 
 //export getBalance

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -75,7 +75,7 @@ type HostContext interface {
 	SetStorage(addr common.Address, key common.Hash, value common.Hash) StorageStatus
 	GetBalance(addr common.Address) common.Hash
 	GetCodeSize(addr common.Address) int
-	GetCodeHash(addr common.Address) (common.Hash, error)
+	GetCodeHash(addr common.Address) common.Hash
 	GetCode(addr common.Address) []byte
 	Selfdestruct(addr common.Address, beneficiary common.Address)
 	GetTxContext() (gasPrice common.Hash, origin common.Address, coinbase common.Address, number int64, timestamp int64,
@@ -123,15 +123,10 @@ func getCodeSize(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.size_t {
 }
 
 //export getCodeHash
-func getCodeHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
+func getCodeHash(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.evmc_bytes32 {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	codeHash, err := ctx.GetCodeHash(goAddress(*pAddr))
-	if err != nil {
-		return false
-	}
-	*pResult = evmcBytes32(codeHash)
-	return true
+	return evmcBytes32(ctx.GetCodeHash(goAddress(*pAddr)))
 }
 
 //export copyCode

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -71,7 +71,7 @@ func goByteSlice(data *C.uint8_t, size C.size_t) []byte {
 
 type HostContext interface {
 	AccountExists(addr common.Address) bool
-	GetStorage(addr common.Address, key common.Hash) (common.Hash, error)
+	GetStorage(addr common.Address, key common.Hash) common.Hash
 	SetStorage(addr common.Address, key common.Hash, value common.Hash) (StorageStatus, error)
 	GetBalance(addr common.Address) (common.Hash, error)
 	GetCodeSize(addr common.Address) (int, error)
@@ -95,15 +95,10 @@ func accountExists(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
 }
 
 //export getStorage
-func getStorage(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32) C.bool {
+func getStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32) C.evmc_bytes32 {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	value, err := ctx.GetStorage(goAddress(*pAddr), goHash(*pKey))
-	if err != nil {
-		return false
-	}
-	*pResult = evmcBytes32(value)
-	return true
+	return evmcBytes32(ctx.GetStorage(goAddress(*pAddr), goHash(*pKey)))
 }
 
 //export setStorage

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -73,7 +73,7 @@ type HostContext interface {
 	AccountExists(addr common.Address) bool
 	GetStorage(addr common.Address, key common.Hash) common.Hash
 	SetStorage(addr common.Address, key common.Hash, value common.Hash) StorageStatus
-	GetBalance(addr common.Address) (common.Hash, error)
+	GetBalance(addr common.Address) common.Hash
 	GetCodeSize(addr common.Address) (int, error)
 	GetCodeHash(addr common.Address) (common.Hash, error)
 	GetCode(addr common.Address) []byte
@@ -105,19 +105,14 @@ func getStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_
 func setStorage(pCtx unsafe.Pointer, pAddr *C.evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	return C.enum_evmc_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)));
+	return C.enum_evmc_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)))
 }
 
 //export getBalance
-func getBalance(pResult *C.evmc_uint256be, pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
+func getBalance(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.evmc_uint256be {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-	balance, err := ctx.GetBalance(goAddress(*pAddr))
-	if err != nil {
-		return false
-	}
-	*pResult = evmcBytes32(balance)
-	return true
+	return evmcBytes32(ctx.GetBalance(goAddress(*pAddr)))
 }
 
 //export getCodeSize

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -52,25 +52,14 @@ static enum evmc_storage_status set_storage(evmc_context* context,
                                             const evmc_bytes32* value)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
-    auto accountIt = host->accounts.find(*address);
-    if (accountIt == host->accounts.end())
-        return EVMC_STORAGE_NON_EXISTING_ACCOUNT;
+    auto& account = host->accounts[*address];
+    auto prevValue = account.storage[*key];
+    account.storage[*key] = *value;
 
-    auto storageIt = accountIt->second.storage.find(*key);
-    if (storageIt == accountIt->second.storage.end())
-    {
-        accountIt->second.storage.emplace(std::make_pair(*key, *value));
-        return EVMC_STORAGE_ADDED;
-    }
-    else if (storageIt->second == *value)
-    {
+    if (prevValue == *value)
         return EVMC_STORAGE_UNCHANGED;
-    }
     else
-    {
-        storageIt->second = *value;
         return EVMC_STORAGE_MODIFIED;
-    }
 }
 
 static bool get_balance(evmc_uint256be* result, evmc_context* context, const evmc_address* address)

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -35,19 +35,15 @@ static bool account_exists(evmc_context* context, const evmc_address* address)
     return host->accounts.find(*address) != host->accounts.end();
 }
 
-static bool get_storage(evmc_bytes32* result,
-                        evmc_context* context,
-                        const evmc_address* address,
-                        const evmc_bytes32* key)
+static evmc_bytes32 get_storage(evmc_context* context,
+                                const evmc_address* address,
+                                const evmc_bytes32* key)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
     if (it != host->accounts.end())
-    {
-        *result = it->second.storage[*key];
-        return true;
-    }
-    return false;
+        return it->second.storage[*key];
+    return {};
 }
 
 static enum evmc_storage_status set_storage(evmc_context* context,

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -80,16 +80,13 @@ static size_t get_code_size(evmc_context* context, const evmc_address* address)
     return 0;
 }
 
-static bool get_code_hash(evmc_bytes32* result, evmc_context* context, const evmc_address* address)
+static evmc_bytes32 get_code_hash(evmc_context* context, const evmc_address* address)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
     if (it != host->accounts.end())
-    {
-        *result = it->second.code_hash;
-        return true;
-    }
-    return false;
+        return it->second.code_hash;
+    return {};
 }
 
 static size_t copy_code(evmc_context* context,

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -71,16 +71,13 @@ static evmc_uint256be get_balance(evmc_context* context, const evmc_address* add
     return {};
 }
 
-static bool get_code_size(size_t* result, evmc_context* context, const evmc_address* address)
+static size_t get_code_size(evmc_context* context, const evmc_address* address)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
     if (it != host->accounts.end())
-    {
-        *result = it->second.code_size;
-        return true;
-    }
-    return false;
+        return it->second.code_size;
+    return 0;
 }
 
 static bool get_code_hash(evmc_bytes32* result, evmc_context* context, const evmc_address* address)

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -62,16 +62,13 @@ static enum evmc_storage_status set_storage(evmc_context* context,
         return EVMC_STORAGE_MODIFIED;
 }
 
-static bool get_balance(evmc_uint256be* result, evmc_context* context, const evmc_address* address)
+static evmc_uint256be get_balance(evmc_context* context, const evmc_address* address)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     auto it = host->accounts.find(*address);
     if (it != host->accounts.end())
-    {
-        *result = it->second.balance;
-        return true;
-    }
-    return false;
+        return it->second.balance;
+    return {};
 }
 
 static bool get_code_size(size_t* result, evmc_context* context, const evmc_address* address)

--- a/examples/example_vm.c
+++ b/examples/example_vm.c
@@ -120,9 +120,8 @@ static struct evmc_result execute(struct evmc_instance* instance,
     }
     else if (code_size == strlen(counter) && strncmp((const char*)code, counter, code_size) == 0)
     {
-        evmc_bytes32 value;
         const evmc_bytes32 key = {{0}};
-        context->host->get_storage(&value, context, &msg->destination, &key);
+        evmc_bytes32 value = context->host->get_storage(context, &msg->destination, &key);
         value.bytes[31]++;
         context->host->set_storage(context, &msg->destination, &key, &value);
         ret.status_code = EVMC_SUCCESS;

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -413,19 +413,15 @@ typedef bool (*evmc_account_exists_fn)(struct evmc_context* context, const evmc_
  *
  * This callback function is used by a VM to query the given contract storage entry.
  *
- * @param[out] result   The pointer to the place where to put the result value.
- * @param      context  The pointer to the Host execution context.
- * @param      address  The address of the account.
- * @param      key      The index of the account's storage entry.
- * @return              If the account exists the value is put at the location
- *                      pointed by @p result and true is returned.
- *                      If the account does not exist false is returned without
- *                      modifying the memory pointed by @p result.
+ * @param context  The Host execution context.
+ * @param address  The address of the account.
+ * @param key      The index of the account's storage entry.
+ * @return         The storage value at the given storage key or null bytes
+ *                 if the account does not exist.
  */
-typedef bool (*evmc_get_storage_fn)(evmc_bytes32* result,
-                                    struct evmc_context* context,
-                                    const evmc_address* address,
-                                    const evmc_bytes32* key);
+typedef evmc_bytes32 (*evmc_get_storage_fn)(struct evmc_context* context,
+                                            const evmc_address* address,
+                                            const evmc_bytes32* key);
 
 
 /**

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -511,19 +511,12 @@ typedef size_t (*evmc_get_code_size_fn)(struct evmc_context* context, const evmc
  * in the account at the given address. For existing accounts not having a code, this
  * function returns keccak256 hash of empty data.
  *
- * @param[out] result   The pointer to the place where to put the result code hash.
- *                      The pointed memory is only modified when the function returns true.
- *                      The pointer MUST NOT be null.
- * @param      context  The pointer to the Host execution context.
- * @param      address  The address of the account.
- * @return              If the account exists the hash of its code is put at the location
- *                      pointed by @p result and true is returned.
- *                      If the account does not exist false is returned without
- *                      modifying the memory pointed by @p result.
+ * @param context  The pointer to the Host execution context.
+ * @param address  The address of the account.
+ * @return         The hash of the code in the account or null bytes if the account does not exist.
  */
-typedef bool (*evmc_get_code_hash_fn)(evmc_bytes32* result,
-                                      struct evmc_context* context,
-                                      const evmc_address* address);
+typedef evmc_bytes32 (*evmc_get_code_hash_fn)(struct evmc_context* context,
+                                              const evmc_address* address);
 
 /**
  * Copy code callback function.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -163,7 +163,7 @@ typedef struct evmc_tx_context (*evmc_get_tx_context_fn)(struct evmc_context* co
  * result code is returned.
  *
  * @param[out] result   The returned block hash value. Only written to
- *                      if the return value is 1 (information is avialable).
+ *                      if the return value is 1 (information is available).
  * @param      context  The pointer to the Host execution context.
  * @param      number   The block number.
  * @return              true if the information is available, false otherwise.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -460,12 +460,7 @@ enum evmc_storage_status
     /**
      * A storage item has been deleted: X -> 0.
      */
-    EVMC_STORAGE_DELETED = 4,
-
-    /**
-     * An attempt to modify storage of an non-existing account.
-     */
-    EVMC_STORAGE_NON_EXISTING_ACCOUNT = 5
+    EVMC_STORAGE_DELETED = 4
 };
 
 
@@ -478,7 +473,7 @@ enum evmc_storage_status
  * @param address  The address of the contract.
  * @param key      The index of the storage entry.
  * @param value    The value to be stored.
- * @return         The effect on the storage item. @see ::evmc_storage_status.
+ * @return         The effect on the storage item.
  */
 typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* context,
                                                         const evmc_address* address,

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -498,19 +498,11 @@ typedef evmc_uint256be (*evmc_get_balance_fn)(struct evmc_context* context,
  * This callback function is used by a VM to get the size of the code stored
  * in the account at the given address.
  *
- * @param[out] result   The pointer to the place where to put the result code size.
- *                      The pointed memory is only modified when the function returns true.
- *                      The pointer MUST NOT be null.
- * @param      context  The pointer to the Host execution context.
- * @param      address  The address of the account.
- * @return              If the account exists the size of its code is put at the location
- *                      pointed by @p result and true is returned.
- *                      If the account does not exist false is returned without
- *                      modifying the memory pointed by @p result.
+ * @param context  The pointer to the Host execution context.
+ * @param address  The address of the account.
+ * @return         The size of the code in the account or 0 if the account does not exist.
  */
-typedef bool (*evmc_get_code_size_fn)(size_t* result,
-                                      struct evmc_context* context,
-                                      const evmc_address* address);
+typedef size_t (*evmc_get_code_size_fn)(struct evmc_context* context, const evmc_address* address);
 
 /**
  * Get code size callback function.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -483,21 +483,14 @@ typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_context* con
 /**
  * Get balance callback function.
  *
- * This callback function is used by a VM to query the balance of the given address.
+ * This callback function is used by a VM to query the balance of the given account.
  *
- * @param[out] result   The pointer to the place where to put the result balance.
- *                      The pointed memory is only modified when the function returns true.
- *                      The pointer MUST NOT be null.
- * @param      context  The pointer to the Host execution context.
- * @param      address  The address of the account.
- * @return              If the account exists its balance is put at the location
- *                      pointed by @p result and true is returned.
- *                      If the account does not exist false is returned without
- *                      modifying the memory pointed by @p result.
+ * @param context  The pointer to the Host execution context.
+ * @param address  The address of the account.
+ * @return         The balance of the given account or 0 if the account does not exist.
  */
-typedef bool (*evmc_get_balance_fn)(evmc_uint256be* result,
-                                    struct evmc_context* context,
-                                    const evmc_address* address);
+typedef evmc_uint256be (*evmc_get_balance_fn)(struct evmc_context* context,
+                                              const evmc_address* address);
 
 /**
  * Get code size callback function.


### PR DESCRIPTION
This reverts most of the Host method changes introduced recently.

Should I also change evmc_get_block_hash_fn?

I tried the previous API in Aleth and it is very messy. Here is an example of trying to expose the information if an account exists when checking balance: https://github.com/ethereum/aleth/pull/5261

This information is not useful in any of the use cases (no place where you would not to fold it to 0 balance).