### PR TITLE
Simplify get_block_hash() method by returning null hash

### DIFF
--- a/bindings/go/evmc/host.c
+++ b/bindings/go/evmc/host.c
@@ -99,8 +99,8 @@ static inline void go_exported_functions_type_checks()
     tx_context = getTxContext(context);
 
     evmc_get_block_hash_fn get_block_hash_fn = NULL;
-    bool_flag = get_block_hash_fn(&bytes32, context, number);
-    bool_flag = getBlockHash(&bytes32, context, number);
+    bytes32 = get_block_hash_fn(context, number);
+    bytes32 = getBlockHash(context, number);
 
     evmc_emit_log_fn emit_log_fn = NULL;
     emit_log_fn(context, address, data, size, &bytes32, size);

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -80,7 +80,7 @@ type HostContext interface {
 	Selfdestruct(addr common.Address, beneficiary common.Address)
 	GetTxContext() (gasPrice common.Hash, origin common.Address, coinbase common.Address, number int64, timestamp int64,
 		gasLimit int64, difficulty common.Hash)
-	GetBlockHash(number int64) (common.Hash, error)
+	GetBlockHash(number int64) common.Hash
 	EmitLog(addr common.Address, topics []common.Hash, data []byte)
 	Call(kind CallKind,
 		destination common.Address, sender common.Address, value *big.Int, input []byte, gas int64, depth int,
@@ -176,17 +176,10 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 }
 
 //export getBlockHash
-func getBlockHash(pResult *C.evmc_bytes32, pCtx unsafe.Pointer, number int64) C.bool {
+func getBlockHash(pCtx unsafe.Pointer, number int64) C.evmc_bytes32 {
 	idx := int((*C.struct_extended_context)(pCtx).index)
 	ctx := getHostContext(idx)
-
-	blockhash, err := ctx.GetBlockHash(number)
-	if err != nil {
-		return false
-	}
-
-	*pResult = evmcBytes32(blockhash)
-	return true
+	return evmcBytes32(ctx.GetBlockHash(number))
 }
 
 //export emitLog

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -128,17 +128,17 @@ static evmc_tx_context get_tx_context(evmc_context* context)
     return result;
 }
 
-static bool get_block_hash(evmc_bytes32* result, evmc_context* context, int64_t number)
+static evmc_bytes32 get_block_hash(evmc_context* context, int64_t number)
 {
     example_host_context* host = static_cast<example_host_context*>(context);
     int64_t current_block_number = host->tx_context.block_number;
 
-    if (number >= current_block_number || number < current_block_number - 256)
-        return false;
-
-    evmc_bytes32 example_block_hash{};
-    *result = example_block_hash;
-    return true;
+    evmc_bytes32 example_block_hash;
+    if (number < current_block_number && number >= current_block_number - 256)
+        example_block_hash = {{1, 1, 1, 1}};
+    else
+        example_block_hash = {};
+    return example_block_hash;
 }
 
 static void emit_log(evmc_context* context,

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -158,19 +158,16 @@ typedef struct evmc_tx_context (*evmc_get_tx_context_fn)(struct evmc_context* co
 /**
  * Get block hash callback function.
  *
- * This callback function is used by an VM to query the block hash of
- * a given block. If the requested block is not found, then an appropriate
- * result code is returned.
+ * This callback function is used by a VM to query the hash of the header of the given block.
+ * If the information about the requested block is not available, then this is signalled by
+ * returning null bytes.
  *
- * @param[out] result   The returned block hash value. Only written to
- *                      if the return value is 1 (information is available).
- * @param      context  The pointer to the Host execution context.
- * @param      number   The block number.
- * @return              true if the information is available, false otherwise.
+ * @param context  The pointer to the Host execution context.
+ * @param number   The block number.
+ * @return         The block hash or null bytes
+ *                 if the information about the block is not available.
  */
-typedef bool (*evmc_get_block_hash_fn)(evmc_bytes32* result,
-                                       struct evmc_context* context,
-                                       int64_t number);
+typedef evmc_bytes32 (*evmc_get_block_hash_fn)(struct evmc_context* context, int64_t number);
 
 /**
  * The execution status code.


### PR DESCRIPTION
Continuation of changes in #154.