### PR TITLE
Enhance compilation tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018 The EVMC Authors.
-# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
 
 cmake_minimum_required(VERSION 3.5)
 
@@ -21,9 +21,9 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 if(EVMC_TESTING)
-	include(HunterGate)
-	include(HunterConfig)
-	include(defaults/HunterCacheServers)
+    include(HunterGate)
+    include(HunterConfig)
+    include(defaults/HunterCacheServers)
 endif()
 
 cable_configure_toolchain(DEFAULT cxx11-pic)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,19 @@ to access Ethereum environment and state.
 
 ## Usage
 
+### Documentation
+
 Please visit the [documentation].
+
+### Languages support
+
+| Language                | Supported Versions  |
+| ----------------------- | ------------------- |
+| **C**                   | C90, C99, C11       |
+| **C++** _(helpers)_[^1] | C++11, C++14, C++17 |
+| **Go** _(bindings)_     | 1.9, 1.10, 1.11     |
+
+[^1]: C++ support is provided by C headers and some optional C++ helpers.
 
 ## Related projects
 

--- a/include/evmc/instructions.h
+++ b/include/evmc/instructions.h
@@ -173,7 +173,7 @@ enum evmc_opcode
 
     OP_REVERT = 0xfd,
     OP_INVALID = 0xfe,
-    OP_SELFDESTRUCT = 0xff,
+    OP_SELFDESTRUCT = 0xff
 };
 
 /**

--- a/include/evmc/loader.h
+++ b/include/evmc/loader.h
@@ -40,7 +40,7 @@ enum evmc_loader_error_code
     EVMC_LOADER_INSTANCE_CREATION_FAILURE = 4,
 
     /** The ABI version of the VM instance has mismatched. */
-    EVMC_LOADER_ABI_VERSION_MISMATCH = 5,
+    EVMC_LOADER_ABI_VERSION_MISMATCH = 5
 };
 
 /**

--- a/test/integration/compilation/CMakeLists.txt
+++ b/test/integration/compilation/CMakeLists.txt
@@ -1,19 +1,32 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018 The EVMC Authors.
-# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
 
-add_library(test-compile-c99 STATIC compilation_test.c)
-target_link_libraries(test-compile-c99 PRIVATE evmc)
-set_target_properties(test-compile-c99 PROPERTIES C_STANDARD 99 C_EXTENSIONS OFF)
+# This CMake script creates multiple additional targets to test the compilation of public headers
+# with different C and C++ standards.
 
-add_library(test-compile-c11 STATIC ${PROJECT_SOURCE_DIR}/include/evmc/evmc.h compilation_test.c)
-target_link_libraries(test-compile-c11 PRIVATE evmc)
-set_target_properties(test-compile-c11 PROPERTIES C_STANDARD 11 C_EXTENSIONS OFF)
+macro(create_compilation_test STANDARD)
+    if (${STANDARD} MATCHES "^(C|CXX)([0-9]+)$")
+        set(lang ${CMAKE_MATCH_1})
+        set(num ${CMAKE_MATCH_2})
+    else()
+        message(FATAL_ERROR "Unknown language standard: ${STANDARD}")
+    endif()
 
-add_library(test-compile-cxx98 STATIC compilation_test.cpp)
-target_link_libraries(test-compile-cxx98 PRIVATE evmc)
-set_target_properties(test-compile-cxx98 PROPERTIES CXX_STANDARD 98 CXX_EXTENSIONS OFF)
+    if (lang STREQUAL CXX)
+        set(ext cpp)
+    else()
+        set(ext c)
+    endif()
 
-add_library(test-compile-cxx11 STATIC compilation_test.cpp)
-target_link_libraries(test-compile-cxx11 PRIVATE evmc)
-set_target_properties(test-compile-cxx11 PROPERTIES CXX_STANDARD 11 CXX_EXTENSIONS OFF)
+    string(TOLOWER ${STANDARD} standard)
+    set(target test-compile-${standard})
+
+    add_library(${target} OBJECT compilation_test.${ext})
+    target_include_directories(${target} PRIVATE ${include_dir})
+    set_target_properties(${target} PROPERTIES ${lang}_STANDARD ${num} ${lang}_EXTENSIONS OFF)
+endmacro()
+
+foreach(standard C90;C99;C11;CXX11;CXX14;CXX17)
+    create_compilation_test(${standard})
+endforeach()

--- a/test/integration/compilation/compilation_test.c
+++ b/test/integration/compilation/compilation_test.c
@@ -1,7 +1,11 @@
 /* EVMC: Ethereum Client-VM Connector API.
- * Copyright 2018 The EVMC Authors.
- * Licensed under the Apache License, Version 2.0. See the LICENSE file.
+ * Copyright 2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
  */
 
+/* Test compilation of C public headers. */
+
 #include <evmc/evmc.h>
+#include <evmc/instructions.h>
+#include <evmc/loader.h>
 #include <evmc/utils.h>

--- a/test/integration/compilation/compilation_test.cpp
+++ b/test/integration/compilation/compilation_test.cpp
@@ -1,7 +1,12 @@
 /* EVMC: Ethereum Client-VM Connector API.
- * Copyright 2018 The EVMC Authors.
- * Licensed under the Apache License, Version 2.0. See the LICENSE file.
+ * Copyright 2019 The EVMC Authors.
+ * Licensed under the Apache License, Version 2.0.
  */
 
+// Test compilation of C and C++ public headers.
+
 #include <evmc/evmc.h>
+#include <evmc/instructions.h>
+#include <evmc/loader.h>
 #include <evmc/utils.h>
+#include <evmc/helpers.hpp>


### PR DESCRIPTION
- Add tests for C90, C++14 and C++17.
- Make CMake macro, use OBJECT libraries.
- Include all public headers.

Closes: https://github.com/ethereum/evmc/issues/180.