### PR TITLE
Restrict the availability of EVMC_DEPRECATED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [6.1.1] - Unreleased
+
+- Fixed: [[#190](https://github.com/ethereum/evmc/pull/190)]
+  Compilation with GCC 5 because of the "deprecated" attribute applied
+  to an enum element.
+
 ## [6.1.0] - 2019-01-24
 
 - Added: [[#174](https://github.com/ethereum/evmc/pull/174)]
@@ -103,6 +109,7 @@
   Constantinople: Storage status is reported back from `evmc_set_storage()`.
 
 
+[6.1.1]: https://github.com/ethereum/evmc/compare/v6.1.0...release/6.1
 [6.1.0]: https://github.com/ethereum/evmc/releases/tag/v6.1.0
 [6.0.2]: https://github.com/ethereum/evmc/releases/tag/v6.0.2
 [6.0.1]: https://github.com/ethereum/evmc/releases/tag/v6.0.1

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -11,13 +11,15 @@
 #ifndef EVMC_H
 #define EVMC_H
 
-#ifdef __has_attribute
-#if __has_attribute(deprecated)
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 6)
+/**
+ * Portable declaration of "deprecated" attribute.
+ *
+ * Available for clang and GCC 6+ compilers. The older GCC compilers know
+ * this attribute, but it cannot be applied to enum elements.
+ */
 #define EVMC_DEPRECATED __attribute__((deprecated))
-#endif
-#endif
-
-#ifndef EVMC_DEPRECATED
+#else
 #define EVMC_DEPRECATED
 #endif
 


### PR DESCRIPTION
Define EVMC_DEPRECATED attribute only for GCC 6+ because in older versions attributes cannot be applied to enum elements.