### PR TITLE
Rename Constantinople2 to Petersburg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.2.0] - Unreleased
+
+- Deprecated: [[#196](https://github.com/ethereum/evmc/pull/196)]
+  The `EVMC_CONSTANTINOPLE2` revision name is deprecated, replaced with `EVMC_PETERSBURG`.
+
 ## [6.1.1] - 2019-02-13
 
 - Added: [[#192](https://github.com/ethereum/evmc/pull/192)]
@@ -111,6 +116,7 @@
   Constantinople: Storage status is reported back from `evmc_set_storage()`.
 
 
+[6.2.0]: https://github.com/ethereum/evmc/compare/v6.1.1...master
 [6.1.1]: https://github.com/ethereum/evmc/releases/tag/v6.1.1
 [6.1.0]: https://github.com/ethereum/evmc/releases/tag/v6.1.0
 [6.0.2]: https://github.com/ethereum/evmc/releases/tag/v6.0.2

--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -141,7 +141,7 @@ const (
 	SpuriousDragon   Revision = C.EVMC_SPURIOUS_DRAGON
 	Byzantium        Revision = C.EVMC_BYZANTIUM
 	Constantinople   Revision = C.EVMC_CONSTANTINOPLE
-	Constantinople2  Revision = C.EVMC_CONSTANTINOPLE2
+	Petersburg       Revision = C.EVMC_PETERSBURG
 	Istanbul         Revision = C.EVMC_ISTANBUL
 )
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -756,12 +756,12 @@ enum evmc_revision
     EVMC_CONSTANTINOPLE = 5,
 
     /**
-     * Reserved for the post-Constantinople upgrade. The name is likely to
-     * be changed, but the assigned number should stay.
+     * The Petersburg revision.
      *
-     * The spec draft: https://github.com/ethereum/EIPs/pull/1716.
+     * Other names: Constantinople2, ConstantinopleFix.
+     * https://eips.ethereum.org/EIPS/eip-1716
      */
-    EVMC_CONSTANTINOPLE2 = 6,
+    EVMC_PETERSBURG = 6,
 
     /**
      * The Istanbul revision.
@@ -773,6 +773,13 @@ enum evmc_revision
     /** The maximum EVM revision supported. */
     EVMC_MAX_REVISION = EVMC_ISTANBUL,
 
+
+    /**
+     * Reserved for the post-Constantinople upgrade.
+     *
+     * @deprecated Replaced with ::EVMC_PETERSBURG.
+     */
+    EVMC_CONSTANTINOPLE2 EVMC_DEPRECATED = EVMC_PETERSBURG,
 
     /**
      * The latests EVM revision supported.

--- a/lib/instructions/instruction_metrics.c
+++ b/lib/instructions/instruction_metrics.c
@@ -1322,7 +1322,7 @@ const struct evmc_instruction_metrics* evmc_get_instruction_metrics_table(
     switch (revision)
     {
     case EVMC_ISTANBUL:
-    case EVMC_CONSTANTINOPLE2:
+    case EVMC_PETERSBURG:
     case EVMC_CONSTANTINOPLE:
         return constantinople_metrics;
     case EVMC_BYZANTIUM:

--- a/lib/instructions/instruction_names.c
+++ b/lib/instructions/instruction_names.c
@@ -1046,7 +1046,7 @@ const char* const* evmc_get_instruction_names_table(enum evmc_revision revision)
     switch (revision)
     {
     case EVMC_ISTANBUL:
-    case EVMC_CONSTANTINOPLE2:
+    case EVMC_PETERSBURG:
     case EVMC_CONSTANTINOPLE:
         return constantinople_names;
     case EVMC_BYZANTIUM:


### PR DESCRIPTION
Closes #193.