### PR TITLE
Always generate Rust enums

### DIFF
--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -11,6 +11,10 @@ fn gen_bindings() {
         .generate_comments(true)
         // https://github.com/rust-lang-nursery/rust-bindgen/issues/947#issuecomment-327100002
         .layout_tests(false)
+        // do not generate an empty enum for EVMC_ABI_VERSION
+        .constified_enum("")
+        // generate Rust enums for each evmc enum
+        .rustified_enum("*")
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Output:
```
pub enum evmc_call_kind {
    #[doc = "< Request CALL."]
    EVMC_CALL = 0,
    #[doc = "< Request DELEGATECALL. Valid since Homestead."]
    #[doc = "The value param ignored."]
    EVMC_DELEGATECALL = 1,
    #[doc = "< Request CALLCODE."]
    EVMC_CALLCODE = 2,
    #[doc = "< Request CREATE."]
    EVMC_CREATE = 3,
    #[doc = "< Request CREATE2. Valid since Constantinople."]
    EVMC_CREATE2 = 4,
}
```