### PR TITLE
Add Travis CI for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+branches:
+  only:
+    - master
+    - /^release\/.*$/
+    - travis
+
+matrix:
+  include:
+    - language: cpp
+      os: windows
+
+cache:
+  directories:
+    - C:/Users/travis/.hunter/_Base/Cache
+
+install:
+  - cmake --version
+  - mkdir build && cd build
+  - cmake .. -G "Visual Studio 15 2017 Win64" -DEVMC_TESTING=ON -DCMAKE_INSTALL_PREFIX=$HOME
+  - cmake --build . --config Release --target install
+
+script:
+  - test/Release/evmc-test.exe
+  - $HOME/bin/evmc-vmtester.exe $HOME/bin/evmc-example-vm.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ before_build:
     if ($env:GENERATOR) {
       if (!(test-path build)) { mkdir build }
       cd build
-      cmake -Wno-dev -G "$env:GENERATOR" .. -DBUILD_SHARED_LIBS=ON -DEVMC_TESTING=ON -DCMAKE_INSTALL_PREFIX=C:\install
+      cmake -Wno-dev -G "$env:GENERATOR" .. -DEVMC_TESTING=ON -DCMAKE_INSTALL_PREFIX=C:\install
     }
 
 build_script:

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: "Configure"
           working_directory: ~/build
-          command: cmake ../project -DCMAKE_INSTALL_PREFIX=~/install -DBUILD_SHARED_LIBS=ON -DEVMC_TESTING=ON $CMAKE_OPTIONS
+          command: cmake ../project -DCMAKE_INSTALL_PREFIX=~/install -DEVMC_TESTING=ON $CMAKE_OPTIONS
       - run:
           name: "Build"
           command: cmake --build ~/build

--- a/cmake/HunterConfig.cmake
+++ b/cmake/HunterConfig.cmake
@@ -6,6 +6,6 @@
 # Hunter is going to be initialized only if building with tests,
 # where it is needed to get dependencies.
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.4.tar.gz"
-    SHA1 "8b2255921208517a55c9533c500131387e3c3dd0"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.131.tar.gz"
+    SHA1 "0512ea6392065c8ece808296fddd7d8664d30920"
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018 The EVMC Authors.
-# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
 
 include(GNUInstallDirs)
 
@@ -15,8 +15,12 @@ add_library(evmc-example-host STATIC example_host.cpp)
 target_link_libraries(evmc-example-host PRIVATE evmc)
 
 
-add_library(evmc-example-vm example_vm.c)
+add_library(evmc-example-vm SHARED example_vm.c)
 target_link_libraries(evmc-example-vm PRIVATE evmc)
+
+add_library(evmc-example-vm-static STATIC example_vm.c)
+target_link_libraries(evmc-example-vm-static PRIVATE evmc)
+
 set_source_files_properties(example_vm.c PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION=${PROJECT_VERSION})
 
 

--- a/lib/instructions/CMakeLists.txt
+++ b/lib/instructions/CMakeLists.txt
@@ -1,6 +1,6 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018 The EVMC Authors.
-# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
 
 add_library(
     instructions STATIC
@@ -12,8 +12,5 @@ add_library(
 add_library(evmc::instructions ALIAS instructions)
 set_target_properties(instructions PROPERTIES OUTPUT_NAME evmc-instructions)
 target_include_directories(instructions PUBLIC $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
-if(BUILD_SHARED_LIBS)
-    set_target_properties(instructions PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-endif()
 
 install(TARGETS instructions EXPORT evmcTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -15,5 +15,5 @@ add_executable(
     test_loader.cpp
 )
 
-target_link_libraries(evmc-test PRIVATE loader-mocked evmc-example-vm instructions GTest::gtest GTest::main)
+target_link_libraries(evmc-test PRIVATE loader-mocked evmc-example-vm-static instructions GTest::gtest GTest::main)
 set_target_properties(evmc-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)


### PR DESCRIPTION
This experiments with Travis CI / Windows.
It also fixes the hidden issue with running unit tests on Windows where it was missing the `example_vm.dll` but execution failure was silently ignored by the script.
Also Hunter is upgraded because it contains a fix for Travis CI/Windows environment.