### PR TITLE
cpp: Add Host interface for the Host side

### DIFF
--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -122,7 +122,9 @@ public:
 
 
 /// Wrapper around EVMC host context / host interface.
-class HostContext
+///
+/// To be used by VM implementations as better alternative to using ::evmc_context directly.
+class HostContext : public HostInterface
 {
     evmc_context* context = nullptr;
     evmc_tx_context tx_context = {};
@@ -130,34 +132,34 @@ class HostContext
 public:
     HostContext(evmc_context* context) noexcept : context{context} {}  // NOLINT
 
-    bool account_exists(const evmc_address& address) noexcept
+    bool account_exists(const evmc_address& address) noexcept final
     {
         return context->host->account_exists(context, &address);
     }
 
-    evmc_bytes32 get_storage(const evmc_address& address, const evmc_bytes32& key) noexcept
+    evmc_bytes32 get_storage(const evmc_address& address, const evmc_bytes32& key) noexcept final
     {
         return context->host->get_storage(context, &address, &key);
     }
 
     evmc_storage_status set_storage(const evmc_address& address,
                                     const evmc_bytes32& key,
-                                    const evmc_bytes32& value) noexcept
+                                    const evmc_bytes32& value) noexcept final
     {
         return context->host->set_storage(context, &address, &key, &value);
     }
 
-    evmc_uint256be get_balance(const evmc_address& address) noexcept
+    evmc_uint256be get_balance(const evmc_address& address) noexcept final
     {
         return context->host->get_balance(context, &address);
     }
 
-    size_t get_code_size(const evmc_address& address) noexcept
+    size_t get_code_size(const evmc_address& address) noexcept final
     {
         return context->host->get_code_size(context, &address);
     }
 
-    evmc_bytes32 get_code_hash(const evmc_address& address) noexcept
+    evmc_bytes32 get_code_hash(const evmc_address& address) noexcept final
     {
         return context->host->get_code_hash(context, &address);
     }
@@ -165,17 +167,17 @@ public:
     size_t copy_code(const evmc_address& address,
                      size_t code_offset,
                      uint8_t* buffer_data,
-                     size_t buffer_size) noexcept
+                     size_t buffer_size) noexcept final
     {
         return context->host->copy_code(context, &address, code_offset, buffer_data, buffer_size);
     }
 
-    void selfdestruct(const evmc_address& address, const evmc_address& beneficiary)
+    void selfdestruct(const evmc_address& address, const evmc_address& beneficiary) noexcept final
     {
         context->host->selfdestruct(context, &address, &beneficiary);
     }
 
-    result call(const evmc_message& message) noexcept
+    result call(const evmc_message& message) noexcept final
     {
         return result{context->host->call(context, &message)};
     }
@@ -185,15 +187,15 @@ public:
     /// The implementation caches the received transaction context
     /// by assuming that the block timestamp should never be zero.
     ///
-    /// @return Reference to the cached transaction context.
-    const evmc_tx_context& get_tx_context() noexcept
+    /// @return The cached transaction context.
+    evmc_tx_context get_tx_context() noexcept final
     {
         if (tx_context.block_timestamp == 0)
             tx_context = context->host->get_tx_context(context);
         return tx_context;
     }
 
-    evmc_bytes32 get_block_hash(int64_t number) noexcept
+    evmc_bytes32 get_block_hash(int64_t number) noexcept final
     {
         return context->host->get_block_hash(context, number);
     }
@@ -202,7 +204,7 @@ public:
                   const uint8_t* data,
                   size_t data_size,
                   const evmc_bytes32 topics[],
-                  size_t topics_count) noexcept
+                  size_t topics_count) noexcept final
     {
         context->host->emit_log(context, &address, data, data_size, topics, topics_count);
     }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -80,13 +80,13 @@ private:
 
 
 /// Wrapper around EVMC host context / host interface.
-class host
+class HostContext
 {
     evmc_context* context = nullptr;
     evmc_tx_context tx_context = {};
 
 public:
-    host(evmc_context* context) noexcept : context{context} {}
+    HostContext(evmc_context* context) noexcept : context{context} {}  // NOLINT
 
     bool account_exists(const evmc_address& address) noexcept
     {

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -79,6 +79,48 @@ private:
 };
 
 
+class HostInterface
+{
+public:
+    virtual ~HostInterface() noexcept = default;
+
+    virtual bool account_exists(const evmc_address& addr) noexcept = 0;
+
+    virtual evmc_bytes32 get_storage(const evmc_address& addr,
+                                     const evmc_bytes32& key) noexcept = 0;
+
+    virtual evmc_storage_status set_storage(const evmc_address& addr,
+                                            const evmc_bytes32& key,
+                                            const evmc_bytes32& value) noexcept = 0;
+
+    virtual evmc_uint256be get_balance(const evmc_address& addr) noexcept = 0;
+
+    virtual size_t get_code_size(const evmc_address& addr) noexcept = 0;
+
+    virtual evmc_bytes32 get_code_hash(const evmc_address& addr) noexcept = 0;
+
+    virtual size_t copy_code(const evmc_address& addr,
+                             size_t code_offset,
+                             uint8_t* buffer_data,
+                             size_t buffer_size) noexcept = 0;
+
+    virtual void selfdestruct(const evmc_address& addr,
+                              const evmc_address& beneficiary) noexcept = 0;
+
+    virtual result call(const evmc_message& msg) noexcept = 0;
+
+    virtual evmc_tx_context get_tx_context() noexcept = 0;
+
+    virtual evmc_bytes32 get_block_hash(int64_t block_number) noexcept = 0;
+
+    virtual void emit_log(const evmc_address& addr,
+                          const uint8_t* data,
+                          size_t data_size,
+                          const evmc_bytes32 topics[],
+                          size_t num_topics) noexcept = 0;
+};
+
+
 /// Wrapper around EVMC host context / host interface.
 class HostContext
 {

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -89,8 +89,8 @@ TEST(cpp, host)
     host.selfdestruct(a, a);
     EXPECT_EQ(host.call({}).gas_left, 0);
 
-    auto* tx = &host.get_tx_context();
-    EXPECT_EQ(&host.get_tx_context(), tx);
+    auto tx = host.get_tx_context();
+    EXPECT_EQ(host.get_tx_context().block_number, tx.block_number);
 
     EXPECT_EQ(host.get_block_hash(0), evmc_bytes32{});
 

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -69,7 +69,7 @@ TEST(cpp, host)
     // Use example host to execute all methods from the C++ host wrapper.
 
     auto* host_context = example_host_create_context();
-    auto host = evmc::host{host_context};
+    auto host = evmc::HostContext{host_context};
 
     auto a = evmc_address{{1}};
     auto v = evmc_bytes32{{7, 7, 7}};


### PR DESCRIPTION
This adds the Host part of the C++ API.

The plan was different, to keep it physically separated, but I realized both Host and VM sides of the API implement the same interface... `HostInterface`.

This introduces some naming issues. We have

- `HostInterface` as pure C++ interface
- `HostContext` as wrapper for the host context pointer to be used by VMs, implements `HostInterface`.
- `Host` - the abstract class for Host implementations, implements `HostInterface`.

Suggestions for better names welcome.

Effectively closes https://github.com/ethereum/evmc/issues/189.

The only tunes left for C++ are aliases like `evmc::address = evmc_address`, merging helpers.hpp, maybe add better types for `evmc_address`, `evmc_uint256be`, etc.
