### PR TITLE
vmtester: do not crash if create_vm returns nullptr

### DIFF
--- a/test/vmtester/vmtester.cpp
+++ b/test/vmtester/vmtester.cpp
@@ -16,6 +16,8 @@ evmc_create_fn create_fn;
 std::unique_ptr<evmc_instance, evmc_destroy_fn> create_vm()
 {
     auto vm = create_fn();
+    if (vm == nullptr)
+        return {nullptr, nullptr};
     return {vm, vm->destroy};
 }
 }  // namespace


### PR DESCRIPTION
Split off #233.