### PR TITLE
docs: add ABI version to the documentation 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -21,7 +21,6 @@ values =
 [bumpversion:file:CMakeLists.txt]
 
 [bumpversion:file:include/evmc/evmc.h]
-parse = EVMC_ABI_VERSION = (?P<major>\d+)
 serialize = {major}
 search = EVMC_ABI_VERSION = {current_version}
 replace = EVMC_ABI_VERSION = {new_version}
@@ -32,3 +31,7 @@ search = version = \"{current_version}\"
 [bumpversion:file:bindings/rust/evmc-vm/Cargo.toml]
 search = version = \"{current_version}\"
 
+[bumpversion:file:docs/EVMC.md]
+serialize = {major}
+search = ABI version {current_version}
+replace = ABI version {new_version}

--- a/docs/EVMC.md
+++ b/docs/EVMC.md
@@ -1,5 +1,7 @@
 # EVMC – Ethereum Client-VM Connector API {#mainpage}
 
+**ABI version 6**
+
 The EVMC is the low-level ABI between Ethereum Virtual Machines (EVMs) and
 Ethereum Clients. On the EVM-side it supports classic EVM1 and [ewasm].
 On the Client-side it defines the interface for EVM implementations


### PR DESCRIPTION
Couldn't yet get bumpversion to work properly.