### PR TITLE
 cpp: Change result constructor to take rvalue reference 

### DIFF
--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -102,7 +102,7 @@ public:
         res.output_size = msg.input_size;
         res.output_data = output;
         res.release = [](const evmc_result* r) noexcept { delete[] r->output_data; };
-        return evmc::result{res};
+        return res;
     }
 
     evmc_tx_context get_tx_context() noexcept final { return {}; }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -27,7 +27,17 @@ public:
     using evmc_result::status_code;
 
     /// Converting constructor from raw evmc_result.
-    explicit result(evmc_result const& res) noexcept : evmc_result{res} {}
+    ///
+    /// The constructed object takes ownership and is responsible for releasing
+    /// the provided result. Therefore, the rvalue reference is used to
+    /// indicate the ownership transfer and that
+    /// the raw evmc_result object MUST NOT be used after.
+    ///
+    /// @param raw_result  The rvalue reference to the evmc_result object.
+    result(evmc_result&& raw_result) noexcept : evmc_result{raw_result}  // NOLINT
+    {
+        raw_result.release = nullptr;
+    }
 
     /// Destructor responsible for automatically releasing attached resources.
     ~result() noexcept

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -30,7 +30,7 @@ TEST(cpp, result)
             ++release_called;
         };
 
-        auto res1 = evmc::result{raw_result};
+        auto res1 = evmc::result{std::move(raw_result)};
         auto res2 = std::move(res1);
 
         EXPECT_EQ(release_called, 0);
@@ -136,7 +136,7 @@ TEST(cpp, result_raii)
         raw_result.status_code = EVMC_INTERNAL_ERROR;
         raw_result.release = release_fn;
 
-        auto raii_result = evmc::result{raw_result};
+        auto raii_result = evmc::result{std::move(raw_result)};  // NOLINT
         EXPECT_EQ(raii_result.status_code, EVMC_INTERNAL_ERROR);
         EXPECT_EQ(raii_result.gas_left, 0);
         raii_result.gas_left = -1;
@@ -147,7 +147,7 @@ TEST(cpp, result_raii)
         EXPECT_EQ(raw_result2.gas_left, -1);
         EXPECT_EQ(raw_result.gas_left, 0);
         EXPECT_EQ(raw_result2.release, release_fn);
-        EXPECT_EQ(raw_result.release, release_fn);
+        EXPECT_EQ(raw_result.release, nullptr);  // NOLINT
     }
     EXPECT_EQ(release_called, 0);
 
@@ -156,7 +156,7 @@ TEST(cpp, result_raii)
         raw_result.status_code = EVMC_INTERNAL_ERROR;
         raw_result.release = release_fn;
 
-        auto raii_result = evmc::result{raw_result};
+        auto raii_result = evmc::result{std::move(raw_result)};  // NOLINT
         EXPECT_EQ(raii_result.status_code, EVMC_INTERNAL_ERROR);
     }
     EXPECT_EQ(release_called, 1);
@@ -173,11 +173,11 @@ TEST(cpp, result_move)
         raw.gas_left = -1;
         raw.release = release_fn;
 
-        auto r0 = evmc::result{raw};
-        EXPECT_EQ(r0.gas_left, raw.gas_left);
+        auto r0 = evmc::result{std::move(raw)};  // NOLINT
+        EXPECT_EQ(r0.gas_left, -1);
 
         auto r1 = std::move(r0);
-        EXPECT_EQ(r1.gas_left, raw.gas_left);
+        EXPECT_EQ(r1.gas_left, -1);
     }
     EXPECT_EQ(release_called, 1);
 
@@ -191,8 +191,8 @@ TEST(cpp, result_move)
         raw2.gas_left = 1;
         raw2.release = release_fn;
 
-        auto r1 = evmc::result{raw1};
-        auto r2 = evmc::result{raw2};
+        auto r1 = evmc::result{std::move(raw1)};  // NOLINT
+        auto r2 = evmc::result{std::move(raw2)};  // NOLINT
 
         r2 = std::move(r1);
     }


### PR DESCRIPTION
Closes #285
Changelog entry is missing.