### PR TITLE
rust: add failure() and success() helpers to ExecutionResult

### DIFF
--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -39,6 +39,14 @@ impl ExecutionResult {
         }
     }
 
+    pub fn failure() -> Self {
+        ExecutionResult::new(ffi::evmc_status_code::EVMC_FAILURE, 0, None)
+    }
+
+    pub fn success(_gas_left: i64, _output: Option<Vec<u8>>) -> Self {
+        ExecutionResult::new(ffi::evmc_status_code::EVMC_SUCCESS, _gas_left, _output)
+    }
+
     pub fn get_status_code(&self) -> ffi::evmc_status_code {
         self.status_code
     }

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -19,14 +19,9 @@ extern "C" fn execute(
     let is_create = execution_ctx.get_message().kind == ffi::evmc_call_kind::EVMC_CREATE;
 
     if is_create {
-        ExecutionResult::new(ffi::evmc_status_code::EVMC_FAILURE, 0, None).into()
+        ExecutionResult::failure().into()
     } else {
-        ExecutionResult::new(
-            ffi::evmc_status_code::EVMC_SUCCESS,
-            66,
-            Some(vec![0xc0, 0xff, 0xee]),
-        )
-        .into()
+        ExecutionResult::success(66, Some(vec![0xc0, 0xff, 0xee])).into()
     }
 }
 

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -19,9 +19,9 @@ extern "C" fn execute(
     let is_create = execution_ctx.get_message().kind == ffi::evmc_call_kind::EVMC_CREATE;
 
     if is_create {
-        evmc_vm::ExecutionResult::new(ffi::evmc_status_code::EVMC_FAILURE, 0, None).into()
+        ExecutionResult::new(ffi::evmc_status_code::EVMC_FAILURE, 0, None).into()
     } else {
-        evmc_vm::ExecutionResult::new(
+        ExecutionResult::new(
             ffi::evmc_status_code::EVMC_SUCCESS,
             66,
             Some(vec![0xc0, 0xff, 0xee]),


### PR DESCRIPTION
This handles the two common cases for VMs.