### PR TITLE
cpp: Add missing '#pragma once' in evmc.hpp

### DIFF
--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -2,6 +2,7 @@
  * Copyright 2018-2019 The EVMC Authors.
  * Licensed under the Apache License, Version 2.0.
  */
+#pragma once
 
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>

--- a/test/integration/compilation/compilation_test.cxx
+++ b/test/integration/compilation/compilation_test.cxx
@@ -12,3 +12,12 @@
 #include <evmc/instructions.h>
 #include <evmc/loader.h>
 #include <evmc/utils.h>
+
+// Include again to check if headers have proper include guards.
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+#include <evmc/helpers.h>
+#include <evmc/helpers.hpp>
+#include <evmc/instructions.h>
+#include <evmc/loader.h>
+#include <evmc/utils.h>


### PR DESCRIPTION
Closes #298 