### PR TITLE
C++: Add execute() overloading without evmc_context parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning].
   [[#372](https://github.com/ethereum/evmc/pull/372)]
 - The **Berlin** EVM revision has been added.
   [[#407](https://github.com/ethereum/evmc/pull/407)]
+- In C++ API, an overload for `VM::execute()` has been added that omits
+  the Host context and interface parameters. This is useful for Precompiles VMs
+  that do not interact with the Host.
+  [[#302](https://github.com/ethereum/evmc/pull/302)]
   
 ### Changed
 

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -408,6 +408,23 @@ public:
         return result{m_instance->execute(m_instance, &host, ctx, rev, &msg, code, code_size)};
     }
 
+    /// Executes code without the Host context.
+    ///
+    /// The same as
+    /// execute(const evmc_host_interface&, evmc_host_context*, evmc_revision,
+    ///         const evmc_message&, const uint8_t*, size_t),
+    /// but without providing the Host context and interface.
+    /// This method is for experimental precompiles support where execution is
+    /// guaranteed not to require any Host access.
+    result execute(evmc_revision rev,
+                   const evmc_message& msg,
+                   const uint8_t* code,
+                   size_t code_size) noexcept
+    {
+        return result{
+            m_instance->execute(m_instance, nullptr, nullptr, rev, &msg, code, code_size)};
+    }
+
 private:
     evmc_vm* m_instance = nullptr;
 };

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -358,8 +358,7 @@ TEST(cpp, vm_execute_precompiles)
     msg.input_size = input.size();
     msg.gas = 18;
 
-    constexpr evmc_host_interface null_interface{};
-    auto res = vm.execute(null_interface, nullptr, EVMC_MAX_REVISION, msg, nullptr, 0);
+    auto res = vm.execute(EVMC_MAX_REVISION, msg, nullptr, 0);
     EXPECT_EQ(res.status_code, EVMC_SUCCESS);
     EXPECT_EQ(res.gas_left, 0);
     ASSERT_EQ(res.output_size, input.size());


### PR DESCRIPTION
Closes https://github.com/ethereum/evmc/issues/299. Part of #259.