### PR TITLE
cmake: Add helper for adding vmtester based VM test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [6.3.0] - unreleased
 
+- Added: [[#303](https://github.com/ethereum/evmc/pull/303)]
+  A CMake helper for running evmc-vmtester.
 - Added: [[#313](https://github.com/ethereum/evmc/pull/313)]
   The loader module introduces standardized EVMC module configuration string 
   which contains path to the module and additional options.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ install(
     FILES
     ${CMAKE_CURRENT_BINARY_DIR}/evmcConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/evmcConfigVersion.cmake
+    cmake/EVMC.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/evmc
 )
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,4 +1,6 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/evmcTargets.cmake")
+include(${CMAKE_CURRENT_LIST_DIR}/evmcTargets.cmake)
 check_required_components(evmc)
+
+include(${CMAKE_CURRENT_LIST_DIR}/EVMC.cmake)

--- a/cmake/EVMC.cmake
+++ b/cmake/EVMC.cmake
@@ -1,0 +1,18 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+
+# Adds a CMake test to check the given EVMC VM implementation with the evmc-vmtester tool.
+#
+# evmc_add_vm_test(NAME <test_name> TARGET <vm>)
+# - NAME argument specifies the name of the added test,
+# - TARGET argument specifies the CMake target being a shared library with EVMC VM implementation.
+function(evmc_add_vm_test)
+    if(NOT TARGET evmc::evmc-vmtester)
+        message(FATAL_ERROR "The evmc-vmtester has not been installed with this EVMC package")
+    endif()
+
+    cmake_parse_arguments("" "" NAME;TARGET "" ${ARGN})
+    add_test(NAME ${_NAME} COMMAND $<TARGET_FILE:evmc::evmc-vmtester> $<TARGET_FILE:${_TARGET}>)
+endfunction()

--- a/examples/use_evmc_in_cmake/CMakeLists.txt
+++ b/examples/use_evmc_in_cmake/CMakeLists.txt
@@ -12,3 +12,10 @@ find_package(evmc CONFIG REQUIRED)
 
 add_executable(use_evmc_in_cmake use_evmc_in_cmake.c)
 target_link_libraries(use_evmc_in_cmake PRIVATE evmc::evmc)
+
+
+
+# Only for integration tests.
+if(NOT COMMAND evmc_add_vm_test)
+    message(FATAL_ERROR "Function evmc_add_vm_test() not in EVMC.cmake module")
+endif()

--- a/test/vmtester/CMakeLists.txt
+++ b/test/vmtester/CMakeLists.txt
@@ -2,20 +2,22 @@
 # Copyright 2018-2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
+include(EVMC)
 include(GNUInstallDirs)
 
 add_executable(evmc-vmtester vmtester.hpp vmtester.cpp tests.cpp)
 set_target_properties(evmc-vmtester PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 target_link_libraries(evmc-vmtester PRIVATE evmc loader evmc-example-host GTest::gtest)
 set_source_files_properties(vmtester.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
+add_executable(evmc::evmc-vmtester ALIAS evmc-vmtester)
 
 
-install(TARGETS evmc-vmtester RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS evmc-vmtester EXPORT evmcTargets RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set(prefix ${PROJECT_NAME}/vmtester)
 
-add_test(NAME ${prefix}/examplevm COMMAND evmc-vmtester $<TARGET_FILE:evmc-example-vm>)
-add_test(NAME ${prefix}/example_precompiles_vm COMMAND evmc-vmtester $<TARGET_FILE:evmc-example-precompiles-vm>)
+evmc_add_vm_test(NAME ${prefix}/examplevm TARGET evmc-example-vm)
+evmc_add_vm_test(NAME ${prefix}/example_precompiles_vm TARGET evmc-example-precompiles-vm)
 
 add_test(NAME ${prefix}/help COMMAND evmc-vmtester --version --help)
 set_tests_properties(${prefix}/help PROPERTIES PASS_REGULAR_EXPRESSION "Usage:")


### PR DESCRIPTION
Closes https://github.com/ethereum/evmc/issues/296.
Requires #336, change the CMake command accordingly.

Required testing:
- [x] Hera: https://github.com/ewasm/hera/pull/549,
- [x] evmone: https://github.com/ethereum/evmone/pull/96,
- [x] internal integration test by importing `find_package(evmc CONFIG)`.