### PR TITLE
loader: Destroy VM with incompatible ABI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [[#261](https://github.com/ethereum/evmc/issues/261),
   [#263](https://github.com/ethereum/evmc/pull/263)]
   The `vmtester` tool now builds with MSVC with `/std:c++17`.
+- Fixed:
+  [[#305](https://github.com/ethereum/evmc/issues/305),
+  [#306](https://github.com/ethereum/evmc/pull/306)]
+  A loaded VM with incompatible ABI version is not properly destroyed.
 
 ## [6.2.2] - 2019-05-16
 

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -207,6 +207,7 @@ struct evmc_instance* evmc_load_and_create(const char* filename,
 
     if (!evmc_is_abi_compatible(instance))
     {
+        evmc_destroy(instance);
         *error_code = set_error(EVMC_LOADER_ABI_VERSION_MISMATCH,
                                 "EVMC ABI version %d of %s mismatches the expected version %d",
                                 instance->abi_version, filename, EVMC_ABI_VERSION);

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -118,12 +118,6 @@ static evmc_instance* create_failure()
     return nullptr;
 }
 
-static evmc_instance* create_abi42()
-{
-    static int abi_version = 42;
-    return reinterpret_cast<evmc_instance*>(&abi_version);
-}
-
 TEST_F(loader, load_nonexistent)
 {
     constexpr auto path = "nonexistent";
@@ -282,12 +276,14 @@ TEST_F(loader, load_and_create_failure)
 
 TEST_F(loader, load_and_create_abi_mismatch)
 {
-    setup("abi42.vm", "evmc_create", create_abi42);
+    setup("abi1985.vm", "evmc_create", create_vm_with_wrong_abi);
 
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_create(evmc_test_library_path, &ec);
     EXPECT_TRUE(vm == nullptr);
     EXPECT_EQ(ec, EVMC_LOADER_ABI_VERSION_MISMATCH);
-    EXPECT_STREQ(evmc_last_error_msg(),
-                 "EVMC ABI version 42 of abi42.vm mismatches the expected version 6");
+    const auto expected_error_msg =
+        "EVMC ABI version 1985 of abi1985.vm mismatches the expected version " +
+        std::to_string(EVMC_ABI_VERSION);
+    EXPECT_EQ(evmc_last_error_msg(), expected_error_msg);
 }

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -286,4 +286,5 @@ TEST_F(loader, load_and_create_abi_mismatch)
         "EVMC ABI version 1985 of abi1985.vm mismatches the expected version " +
         std::to_string(EVMC_ABI_VERSION);
     EXPECT_EQ(evmc_last_error_msg(), expected_error_msg);
+    EXPECT_EQ(destroy_count, create_count);
 }


### PR DESCRIPTION
When a VM is loaded but turns out is has incompatible ABI version it should be destroyed before reporting the loading error and returning a null handle.

Fixes #305