### PR TITLE
loader: Fix strcpy_s()

### DIFF
--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -42,12 +42,16 @@
 #define ATTR_FORMAT(...)
 #endif
 
-#if !_WIN32
+#if _WIN32
+#define strcpy_sx strcpy_s
+#else
 /*
- * Provide strcpy_s() for GNU libc.
+ * Limited variant of strcpy_s().
+ *
+ * Provided for C standard libraries where strcpy_s() is not available.
  * The availability check might need to adjusted for other C standard library implementations.
  */
-static void strcpy_s(char* dest, size_t destsz, const char* src)
+static void strcpy_sx(char* restrict dest, size_t destsz, const char* restrict src)
 {
     size_t len = strlen(src);
     if (len > destsz - 1)
@@ -124,7 +128,7 @@ evmc_create_fn evmc_load(const char* filename, enum evmc_loader_error_code* erro
     const char prefix[] = "evmc_create_";
     const size_t prefix_length = strlen(prefix);
     char prefixed_name[sizeof(prefix) + PATH_MAX_LENGTH];
-    strcpy_s(prefixed_name, sizeof(prefixed_name), prefix);
+    strcpy_sx(prefixed_name, sizeof(prefixed_name), prefix);
 
     // Find filename in the path.
     const char* sep_pos = strrchr(filename, '/');
@@ -142,7 +146,7 @@ evmc_create_fn evmc_load(const char* filename, enum evmc_loader_error_code* erro
         name_pos += lib_prefix_length;
 
     char* base_name = prefixed_name + prefix_length;
-    strcpy_s(base_name, PATH_MAX_LENGTH, name_pos);
+    strcpy_sx(base_name, PATH_MAX_LENGTH, name_pos);
 
     // Trim the file extension.
     char* ext_pos = strrchr(prefixed_name, '.');

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -54,14 +54,21 @@
 #if !defined(EVMC_LOADER_MOCK)
 static
 #endif
-    void
+    int
     strcpy_sx(char* restrict dest, size_t destsz, const char* restrict src)
 {
     size_t len = strlen(src);
-    if (len > destsz - 1)
-        len = destsz - 1;
+    if (len >= destsz)
+    {
+        // The input src will not fit into the dest buffer.
+        // Set the first byte of the dest to null to make it effectively empty string
+        // and return error.
+        dest[0] = 0;
+        return 1;
+    }
     memcpy(dest, src, len);
     dest[len] = 0;
+    return 0;
 }
 #endif
 

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -51,7 +51,11 @@
  * Provided for C standard libraries where strcpy_s() is not available.
  * The availability check might need to adjusted for other C standard library implementations.
  */
-static void strcpy_sx(char* restrict dest, size_t destsz, const char* restrict src)
+#if !defined(EVMC_LOADER_MOCK)
+static
+#endif
+    void
+    strcpy_sx(char* restrict dest, size_t destsz, const char* restrict src)
 {
     size_t len = strlen(src);
     if (len > destsz - 1)

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -16,6 +16,13 @@ static constexpr bool is_windows = false;
 #endif
 
 extern "C" {
+#if _WIN32
+#define strcpy_sx strcpy_s
+#else
+/// Declaration of internal function defined in loader.c.
+void strcpy_sx(char* dest, size_t destsz, const char* src);
+#endif
+
 /// The library path expected by mocked evmc_test_load_library().
 extern const char* evmc_test_library_path;
 
@@ -116,6 +123,17 @@ static evmc_instance* create_eee_bbb()
 static evmc_instance* create_failure()
 {
     return nullptr;
+}
+
+TEST_F(loader, strcpy_sx)
+{
+    const auto input = "12";
+    char buf[2] = {0x0f, 0x0e};
+    static_assert(sizeof(input) > sizeof(buf), "");
+
+    strcpy_sx(buf, sizeof(buf), input);
+    EXPECT_EQ(buf[0], 0);
+    EXPECT_EQ(buf[1], 0);
 }
 
 TEST_F(loader, load_nonexistent)


### PR DESCRIPTION
The `strcpy_s() renamed to `strcpy_sx()` to indicate it is not the one from standard library.

The `strcpy_sx()` now reports errors and behaves as `strcpy_s()` when buffer is too small (nulls the buffer). But it does not have all the checks.

Fixes #304 