### PR TITLE
rust: compile examples for cdylib and not dylib 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -176,8 +176,6 @@ jobs:
       - run:
           name: Test with evmc-vmtester
           command: |
-            # FIXME: there is a linking issue with Cargo workspaces, this is to workaround it
-            export LD_LIBRARY_PATH="$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH"
             ~/build/test/evmc-vmtester target/debug/libexamplerustvm.so
 
 workflows:

--- a/examples/example-rust-vm/Cargo.toml
+++ b/examples/example-rust-vm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [lib]
 name = "examplerustvm"
-crate-type = ["staticlib", "dylib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 evmc-sys = { path = "../../bindings/rust/evmc-sys" }


### PR DESCRIPTION
This was such an annoying typo. More: https://doc.rust-lang.org/reference/linkage.html