### PR TITLE
rust: fix some (mostly stylistic) warnings raised by rustc and clippy

### DIFF
--- a/bindings/rust/evmc-declare-tests/src/lib.rs
+++ b/bindings/rust/evmc-declare-tests/src/lib.rs
@@ -3,23 +3,20 @@
  * Licensed under the Apache License, Version 2.0.
  */
 
+use evmc_declare::evmc_declare_vm;
 use evmc_vm::EvmcVm;
 use evmc_vm::ExecutionContext;
 use evmc_vm::ExecutionResult;
-#[macro_use]
-use evmc_declare::evmc_declare_vm;
 
 #[evmc_declare_vm("Foo VM", "ewasm, evm", "1.42-alpha.gamma.starship")]
-pub struct FooVM {
-    a: i32,
-}
+pub struct FooVM {}
 
 impl EvmcVm for FooVM {
     fn init() -> Self {
-        FooVM { a: 105023 }
+        FooVM {}
     }
 
-    fn execute(&self, code: &[u8], context: &ExecutionContext) -> ExecutionResult {
+    fn execute(&self, _code: &[u8], _context: &ExecutionContext) -> ExecutionResult {
         ExecutionResult::success(1337, None)
     }
 }

--- a/bindings/rust/evmc-declare/src/lib.rs
+++ b/bindings/rust/evmc-declare/src/lib.rs
@@ -186,8 +186,8 @@ impl VMMetaData {
         };
 
         // Make sure that the only null byte is the terminator we inserted in each string.
-        assert_eq!(vm_name_string.matches("\0").count(), 1);
-        assert_eq!(vm_version_string.matches("\0").count(), 1);
+        assert_eq!(vm_name_string.matches('\0').count(), 1);
+        assert_eq!(vm_version_string.matches('\0').count(), 1);
 
         VMMetaData {
             capabilities: capabilities_flags,

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -9,6 +9,7 @@ use crate::ExecutionResult;
 
 /// Container struct for EVMC instances and user-defined data.
 pub struct EvmcContainer<T: EvmcVm + Sized> {
+    #[allow(dead_code)]
     instance: ::evmc_sys::evmc_instance,
     vm: T,
 }

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -14,7 +14,7 @@ impl EvmcVm for ExampleRustVM {
         ExampleRustVM {}
     }
 
-    fn execute(&self, code: &[u8], context: &ExecutionContext) -> ExecutionResult {
+    fn execute(&self, _code: &[u8], context: &ExecutionContext) -> ExecutionResult {
         let is_create = context.get_message().kind == evmc_sys::evmc_call_kind::EVMC_CREATE;
 
         if is_create {


### PR DESCRIPTION
This should make @chfast happy (https://github.com/ethereum/evmc/pull/325#issuecomment-505371176).