### PR TITLE
ci: Refactor Circle CI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,33 +5,8 @@ executors:
     docker:
       - image: ethereum/cpp-build-env:10
 
-jobs:
-
-  lint:
-    executor: linux
-    steps:
-    - checkout
-    - run:
-        name: "Check code format"
-        command: |
-          clang-format --version
-          find examples include lib test -name '*.hpp' -o -name '*.cpp' -o -name '*.h' -o -name '*.c' | xargs clang-format -i
-          git diff --color --exit-code
-    - run:
-        name: "Run codespell"
-        command: |
-          codespell --quiet-level=4 --ignore-words=./.codespell-whitelist
-    - run:
-        name: "Check bumpversion"
-        command: |
-          export PATH="/home/builder/.local/bin:$PATH"
-          pip3 install bumpversion
-          bumpversion --dry-run --verbose major
-          bumpversion --dry-run --verbose minor
-          bumpversion --dry-run --verbose patch
-
-  build: &build
-    executor: linux
+commands:
+  build_and_test:
     steps:
       - checkout
       - run:
@@ -71,31 +46,64 @@ jobs:
           paths:
             - test/evmc-vmtester
 
+jobs:
+
+  lint:
+    executor: linux
+    steps:
+    - checkout
+    - run:
+        name: "Check code format"
+        command: |
+          clang-format --version
+          find examples include lib test -name '*.hpp' -o -name '*.cpp' -o -name '*.h' -o -name '*.c' | xargs clang-format -i
+          git diff --color --exit-code
+    - run:
+        name: "Run codespell"
+        command: |
+          codespell --quiet-level=4 --ignore-words=./.codespell-whitelist
+    - run:
+        name: "Check bumpversion"
+        command: |
+          export PATH="/home/builder/.local/bin:$PATH"
+          pip3 install bumpversion
+          bumpversion --dry-run --verbose major
+          bumpversion --dry-run --verbose minor
+          bumpversion --dry-run --verbose patch
+
   build-cxx17:
-    <<: *build
+    executor: linux
     environment:
       CC: gcc-8
       CXX: g++-8
       CMAKE_OPTIONS: -DTOOLCHAIN=cxx17-pic
+    steps:
+      - build_and_test
 
   build-cxx14-asan:
-    <<: *build
+    executor: linux
     environment:
       CC: clang-8
       CXX: clang++-8
       CMAKE_OPTIONS: -DTOOLCHAIN=cxx14-pic -DSANITIZE=address
+    steps:
+      - build_and_test
 
   build-gcc6:
-    <<: *build
+    executor: linux
     environment:
       CC: gcc-6
       CXX: g++-6
+    steps:
+      - build_and_test
 
   build-clang38:
-    <<: *build
+    executor: linux
     environment:
       CC: clang-3.8
       CXX: clang++-3.8
+    steps:
+      - build_and_test
 
   test-docs:
     executor: linux

--- a/circle.yml
+++ b/circle.yml
@@ -70,6 +70,35 @@ jobs:
           bumpversion --dry-run --verbose major
           bumpversion --dry-run --verbose minor
           bumpversion --dry-run --verbose patch
+    - run:
+        name: "Test documentation"
+        command: |
+          cat Doxyfile | sed 's/HTML_OUTPUT            = ./HTML_OUTPUT            = ..\/docs/' | doxygen - > doxygen.log 2> doxygen.warnings
+          if [ -s doxygen.warnings ]; then
+            printf '\n\nDoxygen warnings:\n\n'
+            cat doxygen.warnings
+            exit 1
+          fi
+          cat doxygen.log
+    - store_artifacts:
+        path: ~/docs
+        destination: docs
+
+  upload-docs:
+    executor: linux
+    steps:
+      - checkout
+      - run:
+          name: "Generate documentation"
+          command: doxygen Doxyfile
+      - run:
+          name: "Upload documentation"
+          command: |
+            git config user.email "docs-bot@ethereum.org"
+            git config user.name "Documentation Bot"
+            git add --all
+            git commit -m "Update docs"
+            git push -f "https://$GITHUB_TOKEN@github.com/ethereum/evmc.git" HEAD:gh-pages
 
   build-cxx17:
     executor: linux
@@ -104,40 +133,6 @@ jobs:
       CXX: clang++-3.8
     steps:
       - build_and_test
-
-  test-docs:
-    executor: linux
-    steps:
-      - checkout
-      - run:
-          name: "Test documentation"
-          command: |
-            cat Doxyfile | sed 's/HTML_OUTPUT            = ./HTML_OUTPUT            = ..\/docs/' | doxygen - > doxygen.log 2> doxygen.warnings
-            if [ -s doxygen.warnings ]; then
-              printf '\n\nDoxygen warnings:\n\n'
-              cat doxygen.warnings
-              exit 1
-            fi
-            cat doxygen.log
-      - store_artifacts:
-          path: ~/docs
-          destination: docs
-
-  upload-docs:
-    executor: linux
-    steps:
-      - checkout
-      - run:
-          name: "Generate documentation"
-          command: doxygen Doxyfile
-      - run:
-          name: "Upload documentation"
-          command: |
-            git config user.email "docs-bot@ethereum.org"
-            git config user.name "Documentation Bot"
-            git add --all
-            git commit -m "Update docs"
-            git push -f "https://$GITHUB_TOKEN@github.com/ethereum/evmc.git" HEAD:gh-pages
 
   bindings-go-latest:
     docker:
@@ -238,10 +233,9 @@ workflows:
       - bindings-rust-asan-combined:
           requires:
             - build-cxx14-asan
-      - test-docs
       - upload-docs:
           requires:
-            - test-docs
+            - lint
           filters:
             branches:
               only:

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,14 @@
-version: 2
+version: 2.1
+
+executors:
+  linux:
+    docker:
+      - image: ethereum/cpp-build-env:10
+
 jobs:
 
   lint:
-    docker:
-    - image: ethereum/cpp-build-env:10
+    executor: linux
     steps:
     - checkout
     - run:
@@ -26,8 +31,7 @@ jobs:
           bumpversion --dry-run --verbose patch
 
   build: &build
-    docker:
-      - image: ethereum/cpp-build-env:10
+    executor: linux
     steps:
       - checkout
       - run:
@@ -87,15 +91,14 @@ jobs:
       CC: gcc-6
       CXX: g++-6
 
-  build-clang3.8:
+  build-clang38:
     <<: *build
     environment:
       CC: clang-3.8
       CXX: clang++-3.8
 
   test-docs:
-    docker:
-      - image: ethereum/cpp-build-env:10
+    executor: linux
     steps:
       - checkout
       - run:
@@ -113,8 +116,7 @@ jobs:
           destination: docs
 
   upload-docs:
-    docker:
-      - image: ethereum/cpp-build-env:10
+    executor: linux
     steps:
       - checkout
       - run:
@@ -219,7 +221,7 @@ workflows:
       - build-cxx17
       - build-cxx14-asan
       - build-gcc6
-      - build-clang3.8
+      - build-clang38
       - bindings-go-latest
       - bindings-go-min
       - bindings-rust:


### PR DESCRIPTION
Use CircleCI 2.1 which allows creating groups of steps and reuse them in job specifications.
This change is mostly motivated by the #327 where I need to modify jobs for 32-bit builds but still want to use the common build steps.