### PR TITLE
rust: make ExecutionContext optional in EvmcVm.execute()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning].
 - The helper function `evmc_is_abi_compatible()` returns now `bool`
   instead of `int`.
   [[#442](https://github.com/ethereum/evmc/pull/442)]
+- In the Rust bindings make `ExecutionContext` optional within `execute`.
+  [[#350](https://github.com/ethereum/evmc/pull/350)]
 
 
 ## [6.3.1] - 2019-08-19

--- a/bindings/rust/evmc-declare-tests/src/lib.rs
+++ b/bindings/rust/evmc-declare-tests/src/lib.rs
@@ -22,7 +22,7 @@ impl EvmcVm for FooVM {
         _revision: evmc_sys::evmc_revision,
         _code: &[u8],
         _message: &ExecutionMessage,
-        _context: &mut ExecutionContext,
+        _context: Option<&mut ExecutionContext>,
     ) -> ExecutionResult {
         ExecutionResult::success(1337, None)
     }

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -69,7 +69,7 @@ mod tests {
             _revision: evmc_sys::evmc_revision,
             _code: &[u8],
             _message: &ExecutionMessage,
-            _context: &mut ExecutionContext,
+            _context: Option<&mut ExecutionContext>,
         ) -> ExecutionResult {
             ExecutionResult::failure()
         }
@@ -142,7 +142,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &mut context,
+                    Some(&mut context)
                 )
                 .status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE
@@ -158,7 +158,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &mut context,
+                    Some(&mut context)
                 )
                 .status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -25,7 +25,7 @@ pub trait EvmcVm {
         revision: ffi::evmc_revision,
         code: &'a [u8],
         message: &'a ExecutionMessage,
-        context: &'a mut ExecutionContext<'a>,
+        context: Option<&'a mut ExecutionContext<'a>>,
     ) -> ExecutionResult;
 }
 

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -19,8 +19,13 @@ impl EvmcVm for ExampleRustVM {
         _revision: evmc_sys::evmc_revision,
         _code: &'a [u8],
         message: &'a ExecutionMessage,
-        _context: &'a mut ExecutionContext<'a>,
+        _context: Option<&'a mut ExecutionContext<'a>>,
     ) -> ExecutionResult {
+        if _context.is_none() {
+            return ExecutionResult::failure();
+        }
+        let _context = _context.unwrap();
+
         if message.kind() != evmc_sys::evmc_call_kind::EVMC_CALL {
             return ExecutionResult::failure();
         }

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -6,7 +6,7 @@
 use evmc_declare::evmc_declare_vm;
 use evmc_vm::*;
 
-#[evmc_declare_vm("ExampleRustVM", "evm", "6.3.0-dev")]
+#[evmc_declare_vm("ExampleRustVM", "evm, precompiles", "6.3.0-dev")]
 pub struct ExampleRustVM;
 
 impl EvmcVm for ExampleRustVM {


### PR DESCRIPTION
Fixes #318.