### PR TITLE
rust: pass ExecutionMessage directly to EvmcVm.execute()

### DIFF
--- a/bindings/rust/evmc-declare-tests/src/lib.rs
+++ b/bindings/rust/evmc-declare-tests/src/lib.rs
@@ -6,6 +6,7 @@
 use evmc_declare::evmc_declare_vm;
 use evmc_vm::EvmcVm;
 use evmc_vm::ExecutionContext;
+use evmc_vm::ExecutionMessage;
 use evmc_vm::ExecutionResult;
 
 #[evmc_declare_vm("Foo VM", "ewasm, evm", "1.42-alpha.gamma.starship")]
@@ -16,7 +17,12 @@ impl EvmcVm for FooVM {
         FooVM {}
     }
 
-    fn execute(&self, _code: &[u8], _context: &ExecutionContext) -> ExecutionResult {
+    fn execute(
+        &self,
+        _code: &[u8],
+        _message: &ExecutionMessage,
+        _context: &ExecutionContext,
+    ) -> ExecutionResult {
         ExecutionResult::success(1337, None)
     }
 }

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -14,8 +14,13 @@ impl EvmcVm for ExampleRustVM {
         ExampleRustVM {}
     }
 
-    fn execute(&self, _code: &[u8], context: &ExecutionContext) -> ExecutionResult {
-        let is_create = context.get_message().kind() == evmc_sys::evmc_call_kind::EVMC_CREATE;
+    fn execute(
+        &self,
+        _code: &[u8],
+        message: &ExecutionMessage,
+        _context: &ExecutionContext,
+    ) -> ExecutionResult {
+        let is_create = message.kind() == evmc_sys::evmc_call_kind::EVMC_CREATE;
 
         if is_create {
             ExecutionResult::failure()


### PR DESCRIPTION
Part of #318.

Also message is a key input to execution, it shouldn't be hidden inside the "frame context".