### PR TITLE
C++: Add basic types based on C types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   Full support for 32-bit architectures has been added.
 - Added: [[#341](https://github.com/ethereum/evmc/pull/341)]
   Support for moving `evmc::vm` objects in C++ API.
+- Added: [[#357](https://github.com/ethereum/evmc/pull/357)]
+  The basic types `address` and `bytes32` have received their C++ wrappers 
+  to assure they are always initialized. They also have convenient operator
+  overloadings for comparison and usage as keys in standard containers.
 - Changed: [[#293](https://github.com/ethereum/evmc/pull/293)]
   In C++ API `evmc::result::raw()` renamed to `evmc::result::release_raw()`.
 - Changed: [[#311](https://github.com/ethereum/evmc/pull/311)]

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -9,21 +9,20 @@
 #include "example_host.h"
 
 #include <evmc/evmc.hpp>
-#include <evmc/helpers.hpp>
 
 #include <map>
 
 struct account
 {
-    evmc_uint256be balance = {};
+    evmc::uint256be balance = {};
     size_t code_size = 0;
-    evmc_bytes32 code_hash = {};
-    std::map<evmc_bytes32, evmc_bytes32> storage;
+    evmc::bytes32 code_hash = {};
+    std::map<evmc::bytes32, evmc::bytes32> storage;
 };
 
 class ExampleHost : public evmc::Host
 {
-    std::map<evmc_address, account> accounts;
+    std::map<evmc::address, account> accounts;
 
 public:
     bool account_exists(const evmc_address& addr) noexcept final
@@ -111,9 +110,9 @@ public:
     {
         int64_t current_block_number = get_tx_context().block_number;
 
-        auto example_block_hash = evmc_bytes32{};
+        auto example_block_hash = evmc::bytes32{};
         if (number < current_block_number && number >= current_block_number - 256)
-            example_block_hash = {{1, 1, 1, 1}};
+            example_block_hash = evmc::bytes32{{{1, 1, 1, 1}}};
         return example_block_hash;
     }
 

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -24,6 +24,9 @@ struct address : evmc_address
     ///
     /// Initializes bytes to zeros if not other @p init value provided.
     constexpr address(evmc_address init = {}) noexcept : evmc_address{init} {}
+
+    /// Explicit operator converting to bool.
+    constexpr inline explicit operator bool() const noexcept;
 };
 
 /// The fixed size array of 32 bytes for storing 256-bit EVM values.
@@ -35,6 +38,9 @@ struct bytes32 : evmc_bytes32
     ///
     /// Initializes bytes to zeros if not other @p init value provided.
     constexpr bytes32(evmc_bytes32 init = {}) noexcept : evmc_bytes32{init} {}
+
+    /// Explicit operator converting to bool.
+    constexpr inline explicit operator bool() const noexcept;
 };
 
 /// Loads 64 bits / 8 bytes of data from the given @p bytes array in big-endian order.
@@ -116,6 +122,28 @@ constexpr bool operator<(const bytes32& a, const bytes32& b) noexcept
             load64be(&a.bytes[16]) < load64be(&b.bytes[16])) ||
            (load64be(&a.bytes[16]) == load64be(&b.bytes[16]) &&
             load64be(&a.bytes[24]) < load64be(&b.bytes[24]));
+}
+
+/// Checks if the given address is the zero address.
+constexpr inline bool is_zero(const address& a) noexcept
+{
+    return a == address{};
+}
+
+constexpr address::operator bool() const noexcept
+{
+    return !is_zero(*this);
+}
+
+/// Checks if the given bytes32 object has all zero bytes.
+constexpr inline bool is_zero(const bytes32& a) noexcept
+{
+    return a == bytes32{};
+}
+
+constexpr bytes32::operator bool() const noexcept
+{
+    return !is_zero(*this);
 }
 
 

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -14,6 +14,28 @@
 /// @ingroup cpp
 namespace evmc
 {
+/// The big-endian 160-bit hash suitable for keeping an Ethereum address.
+///
+/// This type wraps C ::evmc_address to make sure objects of this type are always initialized.
+struct address : evmc_address
+{
+    /// Default and converting constructor.
+    ///
+    /// Initializes bytes to zeros if not other @p init value provided.
+    constexpr address(evmc_address init = {}) noexcept : evmc_address{init} {}
+};
+
+/// The fixed size array of 32 bytes for storing 256-bit EVM values.
+///
+/// This type wraps C ::evmc_bytes32 to make sure objects of this type are always initialized.
+struct bytes32 : evmc_bytes32
+{
+    /// Default and converting constructor.
+    ///
+    /// Initializes bytes to zeros if not other @p init value provided.
+    constexpr bytes32(evmc_bytes32 init = {}) noexcept : evmc_bytes32{init} {}
+};
+
 /// @copydoc evmc_result
 ///
 /// This is a RAII wrapper for evmc_result and objects of this type

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -43,6 +43,10 @@ struct bytes32 : evmc_bytes32
     constexpr inline explicit operator bool() const noexcept;
 };
 
+/// The alias for evmc::bytes32 to represent a big-endian 256-bit integer.
+using uint256be = bytes32;
+
+
 /// Loads 64 bits / 8 bytes of data from the given @p bytes array in big-endian order.
 constexpr inline uint64_t load64be(const uint8_t* bytes) noexcept
 {

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -10,7 +10,6 @@
 #include "../../examples/example_vm/example_vm.h"
 
 #include <evmc/evmc.hpp>
-#include <evmc/helpers.hpp>
 
 #include <gtest/gtest.h>
 
@@ -286,8 +285,8 @@ TEST(cpp, host)
     auto* host_context = example_host_create_context();
     auto host = evmc::HostContext{host_context};
 
-    auto a = evmc_address{{1}};
-    auto v = evmc_bytes32{{7, 7, 7}};
+    const auto a = evmc::address{{{1}}};
+    const auto v = evmc::bytes32{{{7, 7, 7}}};
 
     EXPECT_FALSE(host.account_exists(a));
 
@@ -295,10 +294,10 @@ TEST(cpp, host)
     EXPECT_EQ(host.set_storage(a, {}, v), EVMC_STORAGE_UNCHANGED);
     EXPECT_EQ(host.get_storage(a, {}), v);
 
-    EXPECT_TRUE(is_zero(host.get_balance(a)));
+    EXPECT_TRUE(evmc::is_zero(host.get_balance(a)));
 
     EXPECT_EQ(host.get_code_size(a), 0);
-    EXPECT_EQ(host.get_code_hash(a), evmc_bytes32{});
+    EXPECT_EQ(host.get_code_hash(a), evmc::bytes32{});
     EXPECT_EQ(host.copy_code(a, 0, nullptr, 0), 0);
 
     host.selfdestruct(a, a);
@@ -306,7 +305,7 @@ TEST(cpp, host)
     auto tx = host.get_tx_context();
     EXPECT_EQ(host.get_tx_context().block_number, tx.block_number);
 
-    EXPECT_EQ(host.get_block_hash(0), evmc_bytes32{});
+    EXPECT_EQ(host.get_block_hash(0), evmc::bytes32{});
 
     host.emit_log(a, nullptr, 0, nullptr, 0);
 

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -21,6 +21,9 @@ TEST(cpp, address)
 {
     evmc::address a;
     EXPECT_EQ(std::count(std::begin(a.bytes), std::end(a.bytes), 0), sizeof(a));
+    EXPECT_TRUE(is_zero(a));
+    EXPECT_FALSE(a);
+    EXPECT_TRUE(!a);
 
     auto other = evmc_address{};
     other.bytes[19] = 0xfe;
@@ -30,12 +33,18 @@ TEST(cpp, address)
     a.bytes[0] = 1;
     other = a;
     EXPECT_TRUE(std::equal(std::begin(a.bytes), std::end(a.bytes), std::begin(other.bytes)));
+    EXPECT_FALSE(is_zero(a));
+    EXPECT_TRUE(a);
+    EXPECT_FALSE(!a);
 }
 
 TEST(cpp, bytes32)
 {
     evmc::bytes32 b;
     EXPECT_EQ(std::count(std::begin(b.bytes), std::end(b.bytes), 0), sizeof(b));
+    EXPECT_TRUE(is_zero(b));
+    EXPECT_FALSE(b);
+    EXPECT_TRUE(!b);
 
     auto other = evmc_bytes32{};
     other.bytes[31] = 0xfe;
@@ -45,6 +54,9 @@ TEST(cpp, bytes32)
     b.bytes[0] = 1;
     other = b;
     EXPECT_TRUE(std::equal(std::begin(b.bytes), std::end(b.bytes), std::begin(other.bytes)));
+    EXPECT_FALSE(is_zero(b));
+    EXPECT_TRUE(b);
+    EXPECT_FALSE(!b);
 }
 
 TEST(cpp, std_hash)

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 
+
 TEST(cpp, address)
 {
     evmc::address a;
@@ -44,6 +45,31 @@ TEST(cpp, bytes32)
     b.bytes[0] = 1;
     other = b;
     EXPECT_TRUE(std::equal(std::begin(b.bytes), std::end(b.bytes), std::begin(other.bytes)));
+}
+
+TEST(cpp, std_hash)
+{
+#pragma warning(push)
+#pragma warning(disable : 4307 /* integral constant overflow */)
+#pragma warning(disable : 4309 /* 'static_cast': truncation of constant value */)
+
+#if !defined(_MSC_VER) || (_MSC_VER >= 1910 /* Only for Visual Studio 2017+ */)
+    static_assert(std::hash<evmc::address>{}({}) == static_cast<size_t>(0xd94d12186c0f2fb7), "");
+    static_assert(std::hash<evmc::bytes32>{}({}) == static_cast<size_t>(0x4d25767f9dce13f5), "");
+#endif
+
+    EXPECT_EQ(std::hash<evmc::address>{}({}), static_cast<size_t>(0xd94d12186c0f2fb7));
+    EXPECT_EQ(std::hash<evmc::bytes32>{}({}), static_cast<size_t>(0x4d25767f9dce13f5));
+
+    auto ea = evmc::address{};
+    std::fill_n(ea.bytes, sizeof(ea), uint8_t{0xee});
+    EXPECT_EQ(std::hash<evmc::address>{}(ea), static_cast<size_t>(0x41dc0178e01b7cd9));
+
+    auto eb = evmc::bytes32{};
+    std::fill_n(eb.bytes, sizeof(eb), uint8_t{0xee});
+    EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
+
+#pragma warning(pop)
 }
 
 TEST(cpp, address_comparison)

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -46,6 +46,85 @@ TEST(cpp, bytes32)
     EXPECT_TRUE(std::equal(std::begin(b.bytes), std::end(b.bytes), std::begin(other.bytes)));
 }
 
+TEST(cpp, address_comparison)
+{
+    const auto zero = evmc::address{};
+    for (size_t i = 0; i < sizeof(evmc::address); ++i)
+    {
+        auto t = evmc::address{};
+        t.bytes[i] = 1;
+        auto u = evmc::address{};
+        u.bytes[i] = 2;
+        auto f = evmc::address{};
+        f.bytes[i] = 0xff;
+
+        EXPECT_TRUE(zero < t);
+        EXPECT_TRUE(zero < u);
+        EXPECT_TRUE(zero < f);
+        EXPECT_TRUE(zero != t);
+        EXPECT_TRUE(zero != u);
+        EXPECT_TRUE(zero != f);
+
+        EXPECT_TRUE(t < u);
+        EXPECT_TRUE(t < f);
+        EXPECT_TRUE(u < f);
+
+        EXPECT_FALSE(u < t);
+        EXPECT_FALSE(f < t);
+        EXPECT_FALSE(f < u);
+
+        EXPECT_TRUE(t != u);
+        EXPECT_TRUE(t != f);
+        EXPECT_TRUE(u != t);
+        EXPECT_TRUE(u != f);
+        EXPECT_TRUE(f != t);
+        EXPECT_TRUE(f != u);
+
+        EXPECT_TRUE(t == t);
+        EXPECT_TRUE(u == u);
+        EXPECT_TRUE(f == f);
+    }
+}
+
+TEST(cpp, bytes32_comparison)
+{
+    const auto zero = evmc::bytes32{};
+    for (size_t i = 0; i < sizeof(evmc::bytes32); ++i)
+    {
+        auto t = evmc::bytes32{};
+        t.bytes[i] = 1;
+        auto u = evmc::bytes32{};
+        u.bytes[i] = 2;
+        auto f = evmc::bytes32{};
+        f.bytes[i] = 0xff;
+
+        EXPECT_TRUE(zero < t);
+        EXPECT_TRUE(zero < u);
+        EXPECT_TRUE(zero < f);
+        EXPECT_TRUE(zero != t);
+        EXPECT_TRUE(zero != u);
+        EXPECT_TRUE(zero != f);
+
+        EXPECT_TRUE(t < u);
+        EXPECT_TRUE(t < f);
+        EXPECT_TRUE(u < f);
+
+        EXPECT_FALSE(u < t);
+        EXPECT_FALSE(f < t);
+        EXPECT_FALSE(f < u);
+
+        EXPECT_TRUE(t != u);
+        EXPECT_TRUE(t != f);
+        EXPECT_TRUE(u != t);
+        EXPECT_TRUE(u != f);
+        EXPECT_TRUE(f != t);
+        EXPECT_TRUE(f != u);
+
+        EXPECT_TRUE(t == t);
+        EXPECT_TRUE(u == u);
+        EXPECT_TRUE(f == f);
+    }
+}
 
 TEST(cpp, result)
 {

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -14,6 +14,8 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <map>
+#include <unordered_map>
 
 
 TEST(cpp, address)
@@ -81,6 +83,31 @@ TEST(cpp, std_hash)
     EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
 
 #pragma warning(pop)
+}
+
+TEST(cpp, std_maps)
+{
+    std::map<evmc::address, bool> addresses;
+    addresses[{}] = true;
+    ASSERT_EQ(addresses.size(), 1);
+    EXPECT_EQ(addresses.begin()->first, evmc::address{});
+
+    std::unordered_map<evmc::address, bool> unordered_addresses;
+    unordered_addresses.emplace(*addresses.begin());
+    addresses.clear();
+    EXPECT_EQ(unordered_addresses.size(), 1);
+    EXPECT_FALSE(unordered_addresses.begin()->first);
+
+    std::map<evmc::bytes32, bool> storage;
+    storage[{}] = true;
+    ASSERT_EQ(storage.size(), 1);
+    EXPECT_EQ(storage.begin()->first, evmc::bytes32{});
+
+    std::unordered_map<evmc::bytes32, bool> unordered_storage;
+    unordered_storage.emplace(*storage.begin());
+    storage.clear();
+    EXPECT_EQ(unordered_storage.size(), 1);
+    EXPECT_FALSE(unordered_storage.begin()->first);
 }
 
 TEST(cpp, address_comparison)

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -16,6 +16,37 @@
 
 #include <cstring>
 
+TEST(cpp, address)
+{
+    evmc::address a;
+    EXPECT_EQ(std::count(std::begin(a.bytes), std::end(a.bytes), 0), sizeof(a));
+
+    auto other = evmc_address{};
+    other.bytes[19] = 0xfe;
+    a = other;
+    EXPECT_TRUE(std::equal(std::begin(a.bytes), std::end(a.bytes), std::begin(other.bytes)));
+
+    a.bytes[0] = 1;
+    other = a;
+    EXPECT_TRUE(std::equal(std::begin(a.bytes), std::end(a.bytes), std::begin(other.bytes)));
+}
+
+TEST(cpp, bytes32)
+{
+    evmc::bytes32 b;
+    EXPECT_EQ(std::count(std::begin(b.bytes), std::end(b.bytes), 0), sizeof(b));
+
+    auto other = evmc_bytes32{};
+    other.bytes[31] = 0xfe;
+    b = other;
+    EXPECT_TRUE(std::equal(std::begin(b.bytes), std::end(b.bytes), std::begin(other.bytes)));
+
+    b.bytes[0] = 1;
+    other = b;
+    EXPECT_TRUE(std::equal(std::begin(b.bytes), std::end(b.bytes), std::begin(other.bytes)));
+}
+
+
 TEST(cpp, result)
 {
     static int release_called = 0;

--- a/test/unittests/test_helpers.cpp
+++ b/test/unittests/test_helpers.cpp
@@ -7,10 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include <map>
-#include <unordered_map>
-
-
 // Compile time checks:
 
 static_assert(sizeof(evmc_bytes32) == 32, "evmc_bytes32 is too big");
@@ -37,25 +33,6 @@ TEST(helpers, fnv1a)
     const uint8_t text[] = {'E', 'V', 'M', 'C'};
     const auto h = fnv1a(text, sizeof(text));
     EXPECT_EQ(h, sizeof(size_t) == 8 ? 0x15e05d6d22fed89a : 0xffaa6a9a);
-}
-
-TEST(helpers, maps)
-{
-    std::map<evmc_address, bool> addresses;
-    addresses[{}] = true;
-    ASSERT_EQ(addresses.size(), 1);
-
-    std::unordered_map<evmc_address, bool> unordered_addresses;
-    unordered_addresses.emplace(*addresses.begin());
-    EXPECT_EQ(unordered_addresses.size(), 1);
-
-    std::map<evmc_bytes32, bool> storage;
-    storage[{}] = true;
-    ASSERT_EQ(storage.size(), 1);
-
-    std::unordered_map<evmc_bytes32, bool> unordered_storage;
-    unordered_storage.emplace(*storage.begin());
-    EXPECT_EQ(unordered_storage.size(), 1);
 }
 
 TEST(helpers, is_zero)

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -5,8 +5,7 @@
 #include "../../examples/example_host.h"
 #include "vmtester.hpp"
 
-#include <evmc/helpers.h>
-#include <evmc/helpers.hpp>
+#include <evmc/evmc.hpp>
 
 #include <array>
 #include <cstring>
@@ -79,7 +78,7 @@ TEST_F(evmc_vm_test, execute_call)
         read_buffer(result.output_data, result.output_size);
     }
 
-    EXPECT_TRUE(is_zero(result.create_address));
+    EXPECT_TRUE(evmc::is_zero(result.create_address));
 
     if (result.release)
         result.release(&result);
@@ -115,7 +114,7 @@ TEST_F(evmc_vm_test, execute_create)
     }
 
     // The VM will never provide the create address.
-    EXPECT_TRUE(is_zero(result.create_address));
+    EXPECT_TRUE(evmc::is_zero(result.create_address));
 
     if (result.release)
         result.release(&result);


### PR DESCRIPTION
The basic types `address` and `bytes32` have received their C++ wrappers to assure they are always initialized. They also have convenient operator overloadings for comparison and usage as keys in standard containers.

Closes https://github.com/ethereum/evmc/issues/352