### PR TITLE
clang-format: Fix includes sorting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,16 +21,37 @@ BreakBeforeTernaryOperators: false
 ColumnLimit:     100
 ConstructorInitializerIndentWidth: 2
 IncludeCategories:
+
+  # Local includes "":
   - Regex:           '^".*'
     Priority:        1
-  - Regex:           '^<boost.*'
-    Priority:        98
-  - Regex:           '^<.*\.h>'
+
+  # Third party libraries:
+  - Regex:           '^<cryptopp/.*'
+    Priority:        70
+
+  # Standard library extensions / common generic purpose libraries:
+  - Regex:           '^<boost/.*'
+    Priority:        80
+
+  # Testing libraries:
+  - Regex:           '^<benchmark/.*'
+    Priority:        90
+  - Regex:           '^<gtest/.*'
+    Priority:        90
+
+  # Public includes <>:
+  - Regex:           '^<.*\.h|hpp>'
     Priority:        2
-  - Regex:           '^<.*'
-    Priority:        99
+
+  # C++ standard library:
+  - Regex:           '^<[^.]*>$'
+    Priority:        100
+
+  # Anything else:
   - Regex:           '.*'
     Priority:        4
+
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: false
 IndentWidth:     4

--- a/test/vmtester/vmtester.cpp
+++ b/test/vmtester/vmtester.cpp
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include "vmtester.hpp"
-#include <evmc/loader.h>
 #include <evmc/evmc.hpp>
+#include <evmc/loader.h>
 #include <iostream>
 #include <memory>
 

--- a/test/vmtester/vmtester.hpp
+++ b/test/vmtester/vmtester.hpp
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 #pragma once
 
-#include <gtest/gtest.h>
 #include <evmc/evmc.hpp>
+#include <gtest/gtest.h>
 
 class evmc_vm_test : public ::testing::Test
 {


### PR DESCRIPTION
The includes sorting config is taken from Aleth with regex for C++ standard library made more restrictive. The functional change is that .h and .hpp files are now equal.