### PR TITLE
examples: extend example to support dynamic loading

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ commands:
           name: "Test"
           command: |
             cmake --build ~/build --target test -- ARGS="-j4 --schedule-random --output-on-failure"
-            ~/build/examples/evmc-example
+            ~/build/examples/evmc-example-static
       - run:
           name: "Install"
           command: cmake --build ~/build --target install

--- a/circle.yml
+++ b/circle.yml
@@ -33,8 +33,7 @@ commands:
             # Test statically linked end-to-end example
             ~/build/examples/evmc-example-static
             # Test dynamically loaded end-to-end example
-            ln -s ~/build/examples/example_vm/libevmc-example-vm.so ~/build/examples/example-vm.so
-            ~/build/examples/evmc-example
+            ~/build/examples/evmc-example ~/build/examples/example_vm/libevmc-example-vm.so
       - run:
           name: "Install"
           command: cmake --build ~/build --target install

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,11 @@ commands:
           name: "Test"
           command: |
             cmake --build ~/build --target test -- ARGS="-j4 --schedule-random --output-on-failure"
+            # Test statically linked end-to-end example
             ~/build/examples/evmc-example-static
+            # Test dynamically loaded end-to-end example
+            ln -s ~/build/examples/example_vm/libevmc-example-vm.so ~/build/examples/example-vm.so
+            ~/build/examples/evmc-example
       - run:
           name: "Install"
           command: cmake --build ~/build --target install

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,5 +16,9 @@ add_subdirectory(example_precompiles_vm)
 add_library(evmc-example-host STATIC example_host.cpp)
 target_link_libraries(evmc-example-host PRIVATE evmc)
 
+add_executable(evmc-example-static example.c)
+target_link_libraries(evmc-example-static PRIVATE evmc-example-host evmc-example-vm-static evmc)
+target_compile_definitions(evmc-example-static PRIVATE STATICALLY_LINKED_EXAMPLE)
+
 add_executable(evmc-example example.c)
-target_link_libraries(evmc-example PRIVATE evmc-example-host evmc-example-vm-static evmc)
+target_link_libraries(evmc-example PRIVATE evmc-example-host evmc evmc::loader)

--- a/examples/example.c
+++ b/examples/example.c
@@ -14,17 +14,20 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-int main()
+int main(int argc, char* argv[])
 {
 #ifdef STATICALLY_LINKED_EXAMPLE
+    (void)argc;
+    (void)argv;
     struct evmc_instance* vm = evmc_create_example_vm();
     if (!vm)
         return EVMC_LOADER_INSTANCE_CREATION_FAILURE;
     if (!evmc_is_abi_compatible(vm))
         return EVMC_LOADER_ABI_VERSION_MISMATCH;
 #else
+    const char* config_string = (argc > 1) ? argv[1] : "example-vm.so";
     enum evmc_loader_error_code error_code;
-    struct evmc_instance* vm = evmc_load_and_configure("example-vm.so", &error_code);
+    struct evmc_instance* vm = evmc_load_and_configure(config_string, &error_code);
     if (!vm)
     {
         printf("Loading error: %d\n", error_code);


### PR DESCRIPTION
Follow up of #365.

The reason I've started doing these changes is two fold:
- to give a better starter example for anyone implementing evmc host (e.g. learning from Solidity's trial and error)
- to test Rust example on CI