### PR TITLE
rust: pass ExecutionContext mutable so it can actually be used with host functions

### DIFF
--- a/bindings/rust/evmc-declare-tests/src/lib.rs
+++ b/bindings/rust/evmc-declare-tests/src/lib.rs
@@ -22,7 +22,7 @@ impl EvmcVm for FooVM {
         _revision: evmc_sys::evmc_revision,
         _code: &[u8],
         _message: &ExecutionMessage,
-        _context: &ExecutionContext,
+        _context: &mut ExecutionContext,
     ) -> ExecutionResult {
         ExecutionResult::success(1337, None)
     }

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -62,7 +62,7 @@ mod tests {
             _revision: evmc_sys::evmc_revision,
             _code: &[u8],
             _message: &ExecutionMessage,
-            _context: &ExecutionContext,
+            _context: &mut ExecutionContext,
         ) -> ExecutionResult {
             ExecutionResult::failure()
         }
@@ -126,7 +126,7 @@ mod tests {
             emit_log: None,
         };
         let mut backing_context = ::evmc_sys::evmc_context { host: &host };
-        let context = ExecutionContext::new(&mut backing_context);
+        let mut context = ExecutionContext::new(&mut backing_context);
 
         let container = EvmcContainer::<TestVm>::new(instance);
         assert_eq!(
@@ -135,7 +135,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &context
+                    &mut context
                 )
                 .get_status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE
@@ -150,7 +150,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &context
+                    &mut context
                 )
                 .get_status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -23,7 +23,7 @@ pub trait EvmcVm {
         revision: ffi::evmc_revision,
         code: &[u8],
         message: &ExecutionMessage,
-        context: &ExecutionContext,
+        context: &mut ExecutionContext,
     ) -> ExecutionResult;
 }
 

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -19,7 +19,7 @@ impl EvmcVm for ExampleRustVM {
         _revision: evmc_sys::evmc_revision,
         _code: &[u8],
         message: &ExecutionMessage,
-        _context: &ExecutionContext,
+        _context: &mut ExecutionContext,
     ) -> ExecutionResult {
         let is_create = message.kind() == evmc_sys::evmc_call_kind::EVMC_CREATE;
 


### PR DESCRIPTION
Part of #370.