### PR TITLE
rust: implement the save_return_block_number example in example-rust-vm

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -199,6 +199,9 @@ jobs:
           name: Test with evmc-vmtester
           command: |
             ~/build/test/evmc-vmtester target/debug/libexamplerustvm.so
+      - run:
+          name: Test with evmc-example
+          command: |
             ~/build/examples/evmc-example target/debug/libexamplerustvm.so
 
   bindings-rust-asan-combined:
@@ -227,6 +230,9 @@ jobs:
           name: Test with evmc-vmtester
           command: |
             ~/build/test/evmc-vmtester target/x86_64-unknown-linux-gnu/debug/libexamplerustvm.so
+      - run:
+          name: Test with evmc-example
+          command: |
             ~/build/examples/evmc-example target/x86_64-unknown-linux-gnu/debug/libexamplerustvm.so
 
 workflows:

--- a/examples/example.c
+++ b/examples/example.c
@@ -50,6 +50,7 @@ int main(int argc, char* argv[])
     tx_context.block_gas_limit = gas * 2;
     struct evmc_context* ctx = example_host_create_context(tx_context);
     struct evmc_message msg;
+    msg.kind = EVMC_CALL;
     msg.sender = addr;
     msg.destination = addr;
     msg.value = value;


### PR DESCRIPTION
Follow up of #388. Depends on #389.