### PR TITLE
rust: properly bind lifetimes in EvmcVm

### DIFF
--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -8,13 +8,19 @@ use crate::EvmcVm;
 use std::ops::Deref;
 
 /// Container struct for EVMC instances and user-defined data.
-pub struct EvmcContainer<T: EvmcVm + Sized> {
+pub struct EvmcContainer<T>
+where
+    T: EvmcVm + Sized,
+{
     #[allow(dead_code)]
     instance: ::evmc_sys::evmc_instance,
     vm: T,
 }
 
-impl<T: EvmcVm + Sized> EvmcContainer<T> {
+impl<T> EvmcContainer<T>
+where
+    T: EvmcVm + Sized,
+{
     /// Basic constructor.
     pub fn new(_instance: ::evmc_sys::evmc_instance) -> Self {
         Self {

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -126,8 +126,8 @@ mod tests {
             emit_log: None,
         };
         let mut backing_context = ::evmc_sys::evmc_context { host: &host };
-        let mut context = ExecutionContext::new(&mut backing_context);
 
+        let mut context = ExecutionContext::new(&mut backing_context);
         let container = EvmcContainer::<TestVm>::new(instance);
         assert_eq!(
             container
@@ -143,6 +143,7 @@ mod tests {
 
         let ptr = unsafe { EvmcContainer::into_ffi_pointer(Box::new(container)) };
 
+        let mut context = ExecutionContext::new(&mut backing_context);
         let container = unsafe { EvmcContainer::<TestVm>::from_ffi_pointer(ptr) };
         assert_eq!(
             container

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -18,12 +18,12 @@ pub use types::*;
 /// Trait EVMC VMs have to implement.
 pub trait EvmcVm {
     fn init() -> Self;
-    fn execute(
+    fn execute<'a>(
         &self,
         revision: ffi::evmc_revision,
-        code: &[u8],
-        message: &ExecutionMessage,
-        context: &mut ExecutionContext,
+        code: &'a [u8],
+        message: &'a ExecutionMessage,
+        context: &'a mut ExecutionContext<'a>,
     ) -> ExecutionResult;
 }
 
@@ -806,7 +806,7 @@ mod tests {
         // sanitizers to complain
         let mut context_raw_copy = context_raw.clone();
 
-        let mut exe_context = ExecutionContext::new(&mut context_raw);
+        let exe_context = ExecutionContext::new(&mut context_raw);
         let a = exe_context.get_tx_context();
         let b = unsafe { get_dummy_tx_context(&mut context_raw_copy as *mut ffi::evmc_context) };
 

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -14,12 +14,12 @@ impl EvmcVm for ExampleRustVM {
         ExampleRustVM {}
     }
 
-    fn execute(
+    fn execute<'a>(
         &self,
         _revision: evmc_sys::evmc_revision,
-        _code: &[u8],
-        message: &ExecutionMessage,
-        _context: &mut ExecutionContext,
+        _code: &'a [u8],
+        message: &'a ExecutionMessage,
+        _context: &'a mut ExecutionContext<'a>,
     ) -> ExecutionResult {
         if message.kind() != evmc_sys::evmc_call_kind::EVMC_CALL {
             return ExecutionResult::failure();


### PR DESCRIPTION
Fixes #370.

Ensures that execute() can borrow-check ExecutionContext correctly.