### PR TITLE
cpp: Fallback to evmc::is_zero() in case the deprecated ::is_zero() is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning].
 
 - Added `LoadAndConfigure` method to the Go API.
   [[#404](https://github.com/ethereum/evmc/pull/404)]
+  
+### Deprecated
+
+- Previously deprecated `is_zero()` helper has been removed, 
+  but replaced with new `evmc::is_zero()` in API compatible way.
+  [[#406](https://github.com/ethereum/evmc/pull/406)]
 
 ### Fixed
 

--- a/include/evmc/helpers.hpp
+++ b/include/evmc/helpers.hpp
@@ -12,10 +12,12 @@
  */
 #pragma once
 
-#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
 
 #include <cstring>
 #include <functional>
+
+using evmc::is_zero;
 
 /// The comparator for std::map<evmc_address, ...>.
 EVMC_DEPRECATED
@@ -43,22 +45,6 @@ EVMC_DEPRECATED
 inline bool operator==(const evmc_bytes32& a, const evmc_bytes32& b)
 {
     return std::memcmp(a.bytes, b.bytes, sizeof(a.bytes)) == 0;
-}
-
-/// Check if the address is zero (all bytes are zeros).
-EVMC_DEPRECATED
-inline bool is_zero(const evmc_address& address) noexcept
-{
-    constexpr auto zero = evmc_address{};
-    return std::memcmp(address.bytes, zero.bytes, sizeof(zero.bytes)) == 0;
-}
-
-/// Check if the hash is zero (all bytes are zeros).
-EVMC_DEPRECATED
-inline bool is_zero(const evmc_bytes32& x) noexcept
-{
-    constexpr auto zero = evmc_bytes32{};
-    return std::memcmp(x.bytes, zero.bytes, sizeof(zero.bytes)) == 0;
 }
 
 /// Parameters for the fnv1a hash function, specialized by the hash result size (size_t).


### PR DESCRIPTION
The deprecated is_zero() is removed, but evmc.hpp is included in helpers.hpp in a way that allows using is_zero() as before. This is more user-friendly solution because now evmc::is_zero() can be used also for C types. Before, the deprecated overloading was selected by the compiler.