### PR TITLE
Add CNAME for evmc.ethereum.org alias

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+evmc.ethereum.org


### PR DESCRIPTION
Finally figured out why we had an issue.

From [the support page](https://help.github.com/en/articles/troubleshooting-custom-domains#cname-already-taken):
> When you add or edit your custom domain in your GitHub Pages site's repository settings, we automatically create a CNAME file in the root of your repository.

So basically the setting was creating the file in the `gh-pages` branch, but our CircleCI task overwrites that from `master`, which didn't had the `CNAME` file.