### PR TITLE
cmake: Upgrade GTest to 1.8.1

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,0 +1,13 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2018-2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+# Local Hunter configuration.
+
+hunter_config(
+    GTest
+    VERSION 1.8.1
+    URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+    SHA1 152b849610d91a9dfa1401293f43230c2e0c33f8
+    CMAKE_ARGS BUILD_GMOCK=OFF gtest_force_shared_crt=ON
+)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -4,10 +4,12 @@
 
 # Local Hunter configuration.
 
+set(gtest_cxx_flags "${CMAKE_CXX_FLAGS_INIT} -DGTEST_HAS_TR1_TUPLE=0")
+
 hunter_config(
     GTest
     VERSION 1.8.1
     URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
     SHA1 152b849610d91a9dfa1401293f43230c2e0c33f8
-    CMAKE_ARGS BUILD_GMOCK=OFF gtest_force_shared_crt=ON
+    CMAKE_ARGS BUILD_GMOCK=OFF gtest_force_shared_crt=ON CMAKE_CXX_FLAGS=${gtest_cxx_flags}
 )

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -8,4 +8,5 @@
 HunterGate(
     URL "https://github.com/ruslo/hunter/archive/v0.23.165.tar.gz"
     SHA1 "5a73f91df5f6109c0bb1104d0c0ee423f7bece79"
+    LOCAL
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,9 @@
 hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
 
+# Disable support for std::tr1::tuple in GTest. This causes problems in Visual Studio 2015.
+set_target_properties(GTest::gtest PROPERTIES INTERFACE_COMPILE_DEFINITIONS GTEST_HAS_TR1_TUPLE=0)
+
 if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
     set(CMAKE_CXX_EXTENSIONS OFF)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(
     test_loader.cpp
 )
 
-target_link_libraries(evmc-unittests PRIVATE loader-mocked evmc-example-vm-static evmc-example-host instructions GTest::gtest GTest::main)
+target_link_libraries(evmc-unittests PRIVATE loader-mocked evmc-example-vm-static evmc-example-host instructions GTest::gtest_main)
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 
 gtest_add_tests(TARGET evmc-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -89,24 +89,24 @@ TEST(cpp, std_maps)
 {
     std::map<evmc::address, bool> addresses;
     addresses[{}] = true;
-    ASSERT_EQ(addresses.size(), 1);
+    ASSERT_EQ(addresses.size(), size_t{1});
     EXPECT_EQ(addresses.begin()->first, evmc::address{});
 
     std::unordered_map<evmc::address, bool> unordered_addresses;
     unordered_addresses.emplace(*addresses.begin());
     addresses.clear();
-    EXPECT_EQ(unordered_addresses.size(), 1);
+    EXPECT_EQ(unordered_addresses.size(), size_t{1});
     EXPECT_FALSE(unordered_addresses.begin()->first);
 
     std::map<evmc::bytes32, bool> storage;
     storage[{}] = true;
-    ASSERT_EQ(storage.size(), 1);
+    ASSERT_EQ(storage.size(), size_t{1});
     EXPECT_EQ(storage.begin()->first, evmc::bytes32{});
 
     std::unordered_map<evmc::bytes32, bool> unordered_storage;
     unordered_storage.emplace(*storage.begin());
     storage.clear();
-    EXPECT_EQ(unordered_storage.size(), 1);
+    EXPECT_EQ(unordered_storage.size(), size_t{1});
     EXPECT_FALSE(unordered_storage.begin()->first);
 }
 
@@ -360,9 +360,9 @@ TEST(cpp, host)
 
     EXPECT_TRUE(evmc::is_zero(host.get_balance(a)));
 
-    EXPECT_EQ(host.get_code_size(a), 0);
+    EXPECT_EQ(host.get_code_size(a), size_t{0});
     EXPECT_EQ(host.get_code_hash(a), evmc::bytes32{});
-    EXPECT_EQ(host.copy_code(a, 0, nullptr, 0), 0);
+    EXPECT_EQ(host.copy_code(a, 0, nullptr, 0), size_t{0});
 
     host.selfdestruct(a, a);
 
@@ -479,7 +479,7 @@ TEST(cpp, result_create_no_output)
     EXPECT_EQ(r.status_code, EVMC_REVERT);
     EXPECT_EQ(r.gas_left, 1);
     EXPECT_FALSE(r.output_data);
-    EXPECT_EQ(r.output_size, 0);
+    EXPECT_EQ(r.output_size, size_t{0});
 }
 
 TEST(cpp, result_create)
@@ -489,7 +489,7 @@ TEST(cpp, result_create)
     EXPECT_EQ(r.status_code, EVMC_FAILURE);
     EXPECT_EQ(r.gas_left, -1);
     ASSERT_TRUE(r.output_data);
-    ASSERT_EQ(r.output_size, 2);
+    ASSERT_EQ(r.output_size, size_t{2});
     EXPECT_EQ(r.output_data[0], 1);
     EXPECT_EQ(r.output_data[1], 2);
 

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -21,7 +21,8 @@
 TEST(cpp, address)
 {
     evmc::address a;
-    EXPECT_EQ(std::count(std::begin(a.bytes), std::end(a.bytes), 0), sizeof(a));
+    EXPECT_EQ(std::count(std::begin(a.bytes), std::end(a.bytes), 0), int{sizeof(a)});
+    EXPECT_EQ(a, evmc::address{});
     EXPECT_TRUE(is_zero(a));
     EXPECT_FALSE(a);
     EXPECT_TRUE(!a);
@@ -42,7 +43,8 @@ TEST(cpp, address)
 TEST(cpp, bytes32)
 {
     evmc::bytes32 b;
-    EXPECT_EQ(std::count(std::begin(b.bytes), std::end(b.bytes), 0), sizeof(b));
+    EXPECT_EQ(std::count(std::begin(b.bytes), std::end(b.bytes), 0), int{sizeof(b)});
+    EXPECT_EQ(b, evmc::bytes32{});
     EXPECT_TRUE(is_zero(b));
     EXPECT_FALSE(b);
     EXPECT_TRUE(!b);

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -97,7 +97,7 @@ TEST(cpp, std_maps)
     std::unordered_map<evmc::address, bool> unordered_addresses;
     unordered_addresses.emplace(*addresses.begin());
     addresses.clear();
-    EXPECT_EQ(unordered_addresses.size(), size_t{1});
+    ASSERT_EQ(unordered_addresses.size(), size_t{1});
     EXPECT_FALSE(unordered_addresses.begin()->first);
 
     std::map<evmc::bytes32, bool> storage;
@@ -108,7 +108,7 @@ TEST(cpp, std_maps)
     std::unordered_map<evmc::bytes32, bool> unordered_storage;
     unordered_storage.emplace(*storage.begin());
     storage.clear();
-    EXPECT_EQ(unordered_storage.size(), size_t{1});
+    ASSERT_EQ(unordered_storage.size(), size_t{1});
     EXPECT_FALSE(unordered_storage.begin()->first);
 }
 

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -201,14 +201,16 @@ TEST_F(loader, load_prefix_aaa)
         "unittests/double_prefix_aaa.evm",
     };
 
+    const auto expected_vm_ptr = reinterpret_cast<evmc_instance*>(0xaaa);
+
     for (auto& path : paths)
     {
         setup(path, "evmc_create_aaa", create_aaa);
         evmc_loader_error_code ec;
-        auto fn = evmc_load(path, &ec);
+        const auto fn = evmc_load(path, &ec);
         EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
         ASSERT_TRUE(fn != nullptr);
-        EXPECT_EQ((uintptr_t)fn(), 0xaaa);
+        EXPECT_EQ(fn(), expected_vm_ptr);
         EXPECT_TRUE(evmc_last_error_msg() == nullptr);
     }
 }
@@ -218,9 +220,10 @@ TEST_F(loader, load_eee_bbb)
     setup("unittests/eee-bbb.dll", "evmc_create_eee_bbb", create_eee_bbb);
     evmc_loader_error_code ec;
     auto fn = evmc_load(evmc_test_library_path, &ec);
+    const auto expected_vm_ptr = reinterpret_cast<evmc_instance*>(0xeeebbb);
     ASSERT_TRUE(fn != nullptr);
     EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
-    EXPECT_EQ((uintptr_t)fn(), 0xeeebbb);
+    EXPECT_EQ(fn(), expected_vm_ptr);
     EXPECT_TRUE(evmc_last_error_msg() == nullptr);
 }
 
@@ -353,7 +356,7 @@ TEST_F(loader, load_and_configure_single_option)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,o=1", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "o");
     EXPECT_EQ(recorded_options[0].second, "1");
     EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
@@ -361,7 +364,7 @@ TEST_F(loader, load_and_configure_single_option)
     recorded_options.clear();
     vm = evmc_load_and_configure("path,O=2", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "O");
     EXPECT_EQ(recorded_options[0].second, "2");
     EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
@@ -376,7 +379,7 @@ TEST_F(loader, load_and_configure_uknown_option)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,z=1", &ec);
     EXPECT_FALSE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "z");
     EXPECT_EQ(recorded_options[0].second, "1");
     EXPECT_EQ(ec, EVMC_LOADER_INVALID_OPTION_NAME);
@@ -386,7 +389,7 @@ TEST_F(loader, load_and_configure_uknown_option)
     recorded_options.clear();
     vm = evmc_load_and_configure("path,x=2,", &ec);
     EXPECT_FALSE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "x");
     EXPECT_EQ(recorded_options[0].second, "2");
     EXPECT_EQ(ec, EVMC_LOADER_INVALID_OPTION_VALUE);
@@ -406,7 +409,7 @@ TEST_F(loader, load_and_configure_multiple_options)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,a=_a,b=_b1,c=_c,b=_b2", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 4);
+    ASSERT_EQ(recorded_options.size(), size_t{4});
     EXPECT_EQ(recorded_options[0].first, "a");
     EXPECT_EQ(recorded_options[0].second, "_a");
     EXPECT_EQ(recorded_options[1].first, "b");
@@ -420,7 +423,7 @@ TEST_F(loader, load_and_configure_multiple_options)
     recorded_options.clear();
     vm = evmc_load_and_configure("path,a=_a,b=_b2,a=_c,", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 3);
+    ASSERT_EQ(recorded_options.size(), size_t{3});
     EXPECT_EQ(recorded_options[0].first, "a");
     EXPECT_EQ(recorded_options[0].second, "_a");
     EXPECT_EQ(recorded_options[1].first, "b");
@@ -441,7 +444,7 @@ TEST_F(loader, load_and_configure_uknown_option_in_sequence)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,a=_a,b=_b,c=_b,", &ec);
     EXPECT_FALSE(vm);
-    ASSERT_EQ(recorded_options.size(), 3);
+    ASSERT_EQ(recorded_options.size(), size_t{3});
     EXPECT_EQ(recorded_options[0].first, "a");
     EXPECT_EQ(recorded_options[0].second, "_a");
     EXPECT_EQ(recorded_options[1].first, "b");
@@ -456,7 +459,7 @@ TEST_F(loader, load_and_configure_uknown_option_in_sequence)
     recorded_options.clear();
     vm = evmc_load_and_configure("path,a=_a,x=_b,c=_c", &ec);
     EXPECT_FALSE(vm);
-    ASSERT_EQ(recorded_options.size(), 2);
+    ASSERT_EQ(recorded_options.size(), size_t{2});
     EXPECT_EQ(recorded_options[0].first, "a");
     EXPECT_EQ(recorded_options[0].second, "_a");
     EXPECT_EQ(recorded_options[1].first, "x");
@@ -476,7 +479,7 @@ TEST_F(loader, load_and_configure_empty_values)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,flag,e=,flag=,e", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 4);
+    ASSERT_EQ(recorded_options.size(), size_t{4});
     EXPECT_EQ(recorded_options[0].first, "flag");
     EXPECT_EQ(recorded_options[0].second, "");
     EXPECT_EQ(recorded_options[1].first, "e");
@@ -499,7 +502,7 @@ TEST_F(loader, load_and_configure_degenerated_names)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,,,=,,=xxx", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 5);
+    ASSERT_EQ(recorded_options.size(), size_t{5});
     EXPECT_EQ(recorded_options[0].first, "");
     EXPECT_EQ(recorded_options[0].second, "");
     EXPECT_EQ(recorded_options[1].first, "");
@@ -526,7 +529,7 @@ TEST_F(loader, load_and_configure_comma_at_the_end)
     evmc_loader_error_code ec;
     auto vm = evmc_load_and_configure("path,x=x,", &ec);
     EXPECT_TRUE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "x");
     EXPECT_EQ(recorded_options[0].second, "x");
     EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
@@ -587,7 +590,7 @@ TEST_F(loader, load_and_configure_error_not_wanted)
 
     auto vm = evmc_load_and_configure("path,f=1", nullptr);
     EXPECT_FALSE(vm);
-    ASSERT_EQ(recorded_options.size(), 1);
+    ASSERT_EQ(recorded_options.size(), size_t{1});
     EXPECT_EQ(recorded_options[0].first, "f");
     EXPECT_EQ(recorded_options[0].second, "1");
     EXPECT_EQ(destroy_count, create_count);

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -74,7 +74,7 @@ TEST_F(evmc_vm_test, execute_call)
 
     if (result.output_data == nullptr)
     {
-        EXPECT_EQ(result.output_size, 0);
+        EXPECT_EQ(result.output_size, size_t{0});
     }
     else
     {
@@ -109,7 +109,7 @@ TEST_F(evmc_vm_test, execute_create)
 
     if (result.output_data == nullptr)
     {
-        EXPECT_EQ(result.output_size, 0);
+        EXPECT_EQ(result.output_size, size_t{0});
     }
     else
     {
@@ -206,7 +206,7 @@ TEST_F(evmc_vm_test, precompile_test)
 
         if (result.output_data == nullptr)
         {
-            EXPECT_EQ(result.output_size, 0);
+            EXPECT_EQ(result.output_size, size_t{0});
         }
         else
         {


### PR DESCRIPTION
This is also fix builds with GCC9.