### PR TITLE
Officially drop C90 standard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@ Please visit the [documentation].
 
 | Language                      | Supported Versions    | Supported Compilers
 | ----------------------------- | --------------------- | ------------------------------
-| **C**                         | C90[¹](#n1), C99, C11 | GCC 6+, clang 3.8+, MSVC 2015+
+| **C**                         | C99, C11              | GCC 6+, clang 3.8+, MSVC 2015+
 | **C++**                       | C++11, C++14, C++17   | GCC 6+, clang 3.8+, MSVC 2015+
 | **Go** _(bindings)_           | 1.9 - 1.12            |
-| **Rust** _(bindings)_[²](#n2) | 2018 edition          | 1.31.0 and newer
+| **Rust** _(bindings)_[¹](#n1) | 2018 edition          | 1.31.0 and newer
 
-<b id="n1">1</b>. The C90 support is limited to the core `evmc.h` header only.\
-<b id="n2">2</b>. Rust support is limited and not complete yet, but it is mostly functional already. Breaking changes are possible at this stage.
+<b id="n1">1</b>. Rust support is limited and not complete yet, but it is mostly functional already. Breaking changes are possible at this stage.
 
 ## Related projects
 

--- a/test/integration/compilation/CMakeLists.txt
+++ b/test/integration/compilation/CMakeLists.txt
@@ -5,7 +5,7 @@
 # This CMake script creates multiple additional targets to test the compilation of public headers
 # with different C and C++ standards.
 
-set(standards c_std_90;c_std_99;c_std_11;cxx_std_11;cxx_std_14)
+set(standards c_std_99;c_std_11;cxx_std_11;cxx_std_14)
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.1)
     list(APPEND standards cxx_std_17)
 endif()

--- a/test/integration/compilation/compilation_test.c
+++ b/test/integration/compilation/compilation_test.c
@@ -6,11 +6,7 @@
 /* Test compilation of C public headers. */
 
 #include <evmc/evmc.h>
+#include <evmc/helpers.h>
 #include <evmc/instructions.h>
 #include <evmc/loader.h>
 #include <evmc/utils.h>
-
-#if _MSC_VER || __STDC_VERSION__ >= 199901
-/* Skip C90 standard because contains inline keyword. */
-#include <evmc/helpers.h>
-#endif


### PR DESCRIPTION
The support for C90 was accidentally broken in v6 in https://github.com/ethereum/evmc/commit/280ff9936308c2d07687bdf833485c5c63098d6f - C90 does not have _Bool type.
I don't see it as a problem in practice.