### PR TITLE
Drop 'const' from the parameter type of evmc_result::release()

### DIFF
--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -28,7 +28,7 @@ static evmc_result execute_identity(const evmc_message* msg)
     result.status_code = EVMC_SUCCESS;
     result.output_data = data;
     result.output_size = msg->input_size;
-    result.release = [](const evmc_result* r) { delete[] r->output_data; };
+    result.release = [](evmc_result* r) { delete[] r->output_data; };
     result.gas_left = gas_left;
     return result;
 }

--- a/examples/example_vm/example_vm.c
+++ b/examples/example_vm/example_vm.c
@@ -68,7 +68,7 @@ static enum evmc_set_option_result set_option(struct evmc_instance* instance,
 
 /// The implementation of the evmc_result::release() method that frees
 /// the output buffer attached to the result object.
-static void free_result_output_data(const struct evmc_result* result)
+static void free_result_output_data(struct evmc_result* result)
 {
     free((uint8_t*)result->output_data);
 }

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -319,9 +319,8 @@ struct evmc_result;
  * This function releases memory (and other resources, if any) assigned to the
  * specified execution result making the result object invalid.
  *
- * @param result  The execution result which resources are to be released. The
- *                result itself it not modified by this function, but becomes
- *                invalid and user MUST discard it as well.
+ * @param result  The execution result which resources are to be released.
+ *                The result object becomes invalid and MUST be discarded.
  *                This MUST NOT be NULL.
  *
  * @note
@@ -329,7 +328,7 @@ struct evmc_result;
  * struct. Think of this as the best possible C language approximation to
  * passing objects by reference.
  */
-typedef void (*evmc_release_result_fn)(const struct evmc_result* result);
+typedef void (*evmc_release_result_fn)(struct evmc_result* result);
 
 /** The EVM code execution result. */
 struct evmc_result

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -115,7 +115,7 @@ static inline struct evmc_result evmc_execute(struct evmc_instance* instance,
 /// but may be also used in other case if convenient.
 ///
 /// @param result The result object.
-static void evmc_free_result_memory(const struct evmc_result* result)
+static void evmc_free_result_memory(struct evmc_result* result)
 {
     free((uint8_t*)result->output_data);
 }

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -231,24 +231,26 @@ TEST(cpp, literals)
 
 TEST(cpp, result)
 {
-    static int release_called = 0;
-    release_called = 0;
-
+    static const uint8_t output = 0;
+    int release_called = 0;
     {
-        EXPECT_EQ(release_called, 0);
         auto raw_result = evmc_result{};
-        raw_result.output_data = static_cast<uint8_t*>(std::malloc(13));
+        evmc_get_optional_storage(&raw_result)->pointer = &release_called;
+        EXPECT_EQ(release_called, 0);
+
+        raw_result.output_data = &output;
         raw_result.release = [](evmc_result* r) {
-            std::free(const_cast<uint8_t*>(r->output_data));
-            ++release_called;
+            EXPECT_EQ(r->output_data, &output);
+            ++*static_cast<int*>(evmc_get_optional_storage(r)->pointer);
         };
+        EXPECT_EQ(release_called, 0);
 
         auto res1 = evmc::result{raw_result};
         auto res2 = std::move(res1);
-
         EXPECT_EQ(release_called, 0);
 
-        [](evmc::result) {}(std::move(res2));
+        auto f = [](evmc::result r) { EXPECT_EQ(r.output_data, &output); };
+        f(std::move(res2));
 
         EXPECT_EQ(release_called, 1);
     }

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -238,7 +238,7 @@ TEST(cpp, result)
         EXPECT_EQ(release_called, 0);
         auto raw_result = evmc_result{};
         raw_result.output_data = static_cast<uint8_t*>(std::malloc(13));
-        raw_result.release = [](const evmc_result* r) {
+        raw_result.release = [](evmc_result* r) {
             std::free(const_cast<uint8_t*>(r->output_data));
             ++release_called;
         };
@@ -405,7 +405,7 @@ TEST(cpp, result_raii)
 {
     static auto release_called = 0;
     release_called = 0;
-    auto release_fn = [](const evmc_result*) noexcept { ++release_called; };
+    auto release_fn = [](evmc_result*) noexcept { ++release_called; };
 
     {
         auto raw_result = evmc_result{};
@@ -441,7 +441,7 @@ TEST(cpp, result_raii)
 TEST(cpp, result_move)
 {
     static auto release_called = 0;
-    auto release_fn = [](const evmc_result*) noexcept { ++release_called; };
+    auto release_fn = [](evmc_result*) noexcept { ++release_called; };
 
     release_called = 0;
     {

--- a/test/unittests/test_helpers.cpp
+++ b/test/unittests/test_helpers.cpp
@@ -36,7 +36,7 @@ TEST(helpers, release_result)
 
     e = false;
     r2 = evmc_result{};
-    r2.release = [](const evmc_result* r) { e = r == &r2; };
+    r2.release = [](evmc_result* r) { e = r == &r2; };
     EXPECT_FALSE(e);
     evmc_release_result(&r2);
     EXPECT_TRUE(e);


### PR DESCRIPTION
Closes #278.