### PR TITLE
Move evmc_host_interface out of evmc_host_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning].
   [[#430](https://github.com/ethereum/evmc/pull/430)]
 - The `evmc_context` renamed to `evmc_host_context`.
   [[#426](https://github.com/ethereum/evmc/pull/426)]
+- The `evmc_host_interface` is now separated from `evmc_host_context`. 
+  This simplifies language bindings which implement the `evmc_host_interface`.
+  [[#427](https://github.com/ethereum/evmc/pull/427)]
 - The `evmc::vm` renamed to `evmc::VM` in C++ API.
   [[#252](https://github.com/ethereum/evmc/pull/252)]
 - Previously deprecated `helpers.hpp` header file has been removed.

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -10,12 +10,6 @@ package evmc
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>
 
-struct extended_context
-{
-    struct evmc_host_context context;
-    int64_t index;
-};
-
 */
 import "C"
 import (
@@ -99,50 +93,43 @@ type HostContext interface {
 
 //export accountExists
 func accountExists(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.bool {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return C.bool(ctx.AccountExists(goAddress(*pAddr)))
 }
 
 //export getStorage
 func getStorage(pCtx unsafe.Pointer, pAddr *C.struct_evmc_address, pKey *C.evmc_bytes32) C.evmc_bytes32 {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return evmcBytes32(ctx.GetStorage(goAddress(*pAddr), goHash(*pKey)))
 }
 
 //export setStorage
 func setStorage(pCtx unsafe.Pointer, pAddr *C.evmc_address, pKey *C.evmc_bytes32, pVal *C.evmc_bytes32) C.enum_evmc_storage_status {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return C.enum_evmc_storage_status(ctx.SetStorage(goAddress(*pAddr), goHash(*pKey), goHash(*pVal)))
 }
 
 //export getBalance
 func getBalance(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.evmc_uint256be {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return evmcBytes32(ctx.GetBalance(goAddress(*pAddr)))
 }
 
 //export getCodeSize
 func getCodeSize(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.size_t {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return C.size_t(ctx.GetCodeSize(goAddress(*pAddr)))
 }
 
 //export getCodeHash
 func getCodeHash(pCtx unsafe.Pointer, pAddr *C.evmc_address) C.evmc_bytes32 {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return evmcBytes32(ctx.GetCodeHash(goAddress(*pAddr)))
 }
 
 //export copyCode
 func copyCode(pCtx unsafe.Pointer, pAddr *C.evmc_address, offset C.size_t, p *C.uint8_t, size C.size_t) C.size_t {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	code := ctx.GetCode(goAddress(*pAddr))
 	length := C.size_t(len(code))
 
@@ -162,15 +149,13 @@ func copyCode(pCtx unsafe.Pointer, pAddr *C.evmc_address, offset C.size_t, p *C.
 
 //export selfdestruct
 func selfdestruct(pCtx unsafe.Pointer, pAddr *C.evmc_address, pBeneficiary *C.evmc_address) {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	ctx.Selfdestruct(goAddress(*pAddr), goAddress(*pBeneficiary))
 }
 
 //export getTxContext
 func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 
 	txContext := ctx.GetTxContext()
 
@@ -188,15 +173,13 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 
 //export getBlockHash
 func getBlockHash(pCtx unsafe.Pointer, number int64) C.evmc_bytes32 {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 	return evmcBytes32(ctx.GetBlockHash(number))
 }
 
 //export emitLog
 func emitLog(pCtx unsafe.Pointer, pAddr *C.evmc_address, pData unsafe.Pointer, dataSize C.size_t, pTopics unsafe.Pointer, topicsCount C.size_t) {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 
 	// FIXME: Optimize memory copy
 	data := C.GoBytes(pData, C.int(dataSize))
@@ -213,8 +196,7 @@ func emitLog(pCtx unsafe.Pointer, pAddr *C.evmc_address, pData unsafe.Pointer, d
 
 //export call
 func call(pCtx unsafe.Pointer, msg *C.struct_evmc_message) C.struct_evmc_result {
-	idx := int((*C.struct_extended_context)(pCtx).index)
-	ctx := getHostContext(idx)
+	ctx := getHostContext(uintptr(pCtx))
 
 	kind := CallKind(msg.kind)
 	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.destination), goAddress(msg.sender), goHash(msg.value).Big(),

--- a/bindings/rust/evmc-declare/src/lib.rs
+++ b/bindings/rust/evmc-declare/src/lib.rs
@@ -346,14 +346,14 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
             use evmc_vm::EvmcVm;
 
             // TODO: context is optional in case of the "precompiles" capability
-            if instance.is_null() || host.is_null() || context.is_null() || msg.is_null() || (code.is_null() && code_size != 0) {
+            if instance.is_null() || host.is_null() || msg.is_null() || (code.is_null() && code_size != 0) {
                 // These are irrecoverable errors that violate the EVMC spec.
                 std::process::abort();
             }
 
             assert!(!instance.is_null());
-            // TODO: context is optional in case of the "precompiles" capability
-            assert!(!context.is_null());
+            // TODO: host is optional in case of the "precompiles" capability
+            assert!(!host.is_null());
             assert!(!msg.is_null());
 
             let execution_message: ::evmc_vm::ExecutionMessage = unsafe {
@@ -379,7 +379,7 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
                 let mut execution_context = unsafe {
                     ::evmc_vm::ExecutionContext::new(
                         host.as_ref().expect("EVMC host is null"),
-                        context.as_mut().expect("EVMC context is null")
+                        context,
                     )
                 };
                 container.execute(revision, code_ref, &execution_message, &mut execution_context)

--- a/bindings/rust/evmc-declare/src/lib.rs
+++ b/bindings/rust/evmc-declare/src/lib.rs
@@ -335,6 +335,7 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
     quote! {
         extern "C" fn __evmc_execute(
             instance: *mut ::evmc_vm::ffi::evmc_vm,
+            host: *const ::evmc_vm::ffi::evmc_host_interface,
             context: *mut ::evmc_vm::ffi::evmc_host_context,
             revision: ::evmc_vm::ffi::evmc_revision,
             msg: *const ::evmc_vm::ffi::evmc_message,
@@ -345,7 +346,7 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
             use evmc_vm::EvmcVm;
 
             // TODO: context is optional in case of the "precompiles" capability
-            if instance.is_null() || context.is_null() || msg.is_null() || (code.is_null() && code_size != 0) {
+            if instance.is_null() || host.is_null() || context.is_null() || msg.is_null() || (code.is_null() && code_size != 0) {
                 // These are irrecoverable errors that violate the EVMC spec.
                 std::process::abort();
             }
@@ -376,7 +377,10 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 
             let result = ::std::panic::catch_unwind(|| {
                 let mut execution_context = unsafe {
-                  ::evmc_vm::ExecutionContext::new(context.as_mut().expect("EVMC context is null"))
+                    ::evmc_vm::ExecutionContext::new(
+                        host.as_ref().expect("EVMC host is null"),
+                        context.as_mut().expect("EVMC context is null")
+                    )
                 };
                 container.execute(revision, code_ref, &execution_message, &mut execution_context)
             });

--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -22,6 +22,7 @@ fn gen_bindings() {
         .rustified_enum("*")
         // force deriving the Hash trait on basic types (address, bytes32)
         .derive_hash(true)
+        .opaque_type("evmc_host_context")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/bindings/rust/evmc-sys/src/lib.rs
+++ b/bindings/rust/evmc-sys/src/lib.rs
@@ -36,6 +36,12 @@ impl Default for evmc_bytes32 {
     }
 }
 
+impl Default for evmc_host_context {
+    fn default() -> Self {
+        evmc_host_context { _unused: [0u8; 0] }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::mem::size_of;

--- a/bindings/rust/evmc-sys/src/lib.rs
+++ b/bindings/rust/evmc-sys/src/lib.rs
@@ -36,12 +36,6 @@ impl Default for evmc_bytes32 {
     }
 }
 
-impl Default for evmc_host_context {
-    fn default() -> Self {
-        evmc_host_context { _unused: [0u8; 0] }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::mem::size_of;

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -59,6 +59,7 @@ mod tests {
     use crate::{ExecutionContext, ExecutionMessage, ExecutionResult};
 
     struct TestVm {}
+
     impl EvmcVm for TestVm {
         fn init() -> Self {
             TestVm {}
@@ -131,9 +132,9 @@ mod tests {
             get_block_hash: None,
             emit_log: None,
         };
-        let mut backing_context = ::evmc_sys::evmc_host_context { host: &host };
+        let mut host_context = ::evmc_sys::evmc_host_context::default();
 
-        let mut context = ExecutionContext::new(&mut backing_context);
+        let mut context = ExecutionContext::new(&host, &mut host_context);
         let container = EvmcContainer::<TestVm>::new(instance);
         assert_eq!(
             container
@@ -141,7 +142,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &mut context
+                    &mut context,
                 )
                 .status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE
@@ -149,7 +150,7 @@ mod tests {
 
         let ptr = unsafe { EvmcContainer::into_ffi_pointer(container) };
 
-        let mut context = ExecutionContext::new(&mut backing_context);
+        let mut context = ExecutionContext::new(&host, &mut host_context);
         let container = unsafe { EvmcContainer::<TestVm>::from_ffi_pointer(ptr) };
         assert_eq!(
             container
@@ -157,7 +158,7 @@ mod tests {
                     evmc_sys::evmc_revision::EVMC_PETERSBURG,
                     &code,
                     &message,
-                    &mut context
+                    &mut context,
                 )
                 .status_code(),
             ::evmc_sys::evmc_status_code::EVMC_FAILURE

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -132,9 +132,9 @@ mod tests {
             get_block_hash: None,
             emit_log: None,
         };
-        let mut host_context = ::evmc_sys::evmc_host_context::default();
+        let host_context = std::ptr::null_mut();
 
-        let mut context = ExecutionContext::new(&host, &mut host_context);
+        let mut context = ExecutionContext::new(&host, host_context);
         let container = EvmcContainer::<TestVm>::new(instance);
         assert_eq!(
             container
@@ -150,7 +150,7 @@ mod tests {
 
         let ptr = unsafe { EvmcContainer::into_ffi_pointer(container) };
 
-        let mut context = ExecutionContext::new(&host, &mut host_context);
+        let mut context = ExecutionContext::new(&host, host_context);
         let container = unsafe { EvmcContainer::<TestVm>::from_ffi_pointer(ptr) };
         assert_eq!(
             container

--- a/examples/example.c
+++ b/examples/example.c
@@ -48,6 +48,7 @@ int main(int argc, char* argv[])
     tx_context.block_number = 42;
     tx_context.block_timestamp = 66;
     tx_context.block_gas_limit = gas * 2;
+    const struct evmc_host_interface* host = example_host_get_interface();
     struct evmc_host_context* ctx = example_host_create_context(tx_context);
     struct evmc_message msg;
     msg.kind = EVMC_CALL;
@@ -58,7 +59,7 @@ int main(int argc, char* argv[])
     msg.input_size = sizeof(input);
     msg.gas = gas;
     msg.depth = 0;
-    struct evmc_result result = evmc_execute(vm, ctx, EVMC_HOMESTEAD, &msg, code, code_size);
+    struct evmc_result result = evmc_execute(vm, host, ctx, EVMC_HOMESTEAD, &msg, code, code_size);
     printf("Execution result:\n");
     int exit_code = 0;
     if (result.status_code != EVMC_SUCCESS)
@@ -77,7 +78,7 @@ int main(int argc, char* argv[])
             printf("%02x", result.output_data[i]);
         printf("\n");
         const evmc_bytes32 storage_key = {{0}};
-        evmc_bytes32 storage_value = ctx->host->get_storage(ctx, &msg.destination, &storage_key);
+        evmc_bytes32 storage_value = host->get_storage(ctx, &msg.destination, &storage_key);
         printf("  Storage at 0x00..00: ");
         for (i = 0; i < sizeof(storage_value.bytes) / sizeof(storage_value.bytes[0]); i++)
             printf("%02x", storage_value.bytes[i]);

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -160,13 +160,19 @@ public:
 
 extern "C" {
 
+const evmc_host_interface* example_host_get_interface()
+{
+    return evmc::Host::get_interface();
+}
+
 evmc_host_context* example_host_create_context(evmc_tx_context tx_context)
 {
-    return new ExampleHost(tx_context);
+    auto host = new ExampleHost{tx_context};
+    return host->to_context();
 }
 
 void example_host_destroy_context(evmc_host_context* context)
 {
-    delete static_cast<ExampleHost*>(context);
+    delete evmc::Host::from_context<ExampleHost>(context);
 }
 }

--- a/examples/example_host.h
+++ b/examples/example_host.h
@@ -9,6 +9,8 @@
 extern "C" {
 #endif
 
+const struct evmc_host_interface* example_host_get_interface();
+
 struct evmc_host_context* example_host_create_context(struct evmc_tx_context tx_context);
 
 void example_host_destroy_context(struct evmc_host_context* context);

--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -48,8 +48,9 @@ static evmc_result not_implemented()
     return result;
 }
 
-static evmc_result execute(evmc_vm*,
-                           evmc_host_context*,
+static evmc_result execute(evmc_vm* /*unused*/,
+                           const evmc_host_interface* /*unused*/,
+                           evmc_host_context* /*unused*/,
                            enum evmc_revision rev,
                            const evmc_message* msg,
                            const uint8_t*,

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -156,6 +156,11 @@ struct evmc_tx_context
     evmc_uint256be chain_id;         /**< The blockchain's ChainID. */
 };
 
+/**
+ * @struct evmc_host_context
+ * The opaque data type representing the Host execution context.
+ * @see evmc_execute_fn().
+ */
 struct evmc_host_context;
 
 /**
@@ -653,22 +658,6 @@ struct evmc_host_interface
 };
 
 
-/**
- * Execution context managed by the Host.
- *
- * The Host MUST pass the pointer to the execution context to ::evmc_execute_fn.
- * The VM MUST pass the same pointer back to the Host in every callback function.
- * The context MUST contain at least the function table defining
- * the context callback interface.
- * Optionally, the Host MAY include in the context additional data.
- */
-struct evmc_host_context
-{
-    /** The Host interface. */
-    const struct evmc_host_interface* host;
-};
-
-
 /* Forward declaration. */
 struct evmc_vm;
 
@@ -791,10 +780,12 @@ enum evmc_revision
  * This function MAY be invoked multiple times for a single VM instance.
  *
  * @param vm         The VM instance. This argument MUST NOT be NULL.
- * @param context    The pointer to the Host execution context to be passed
- *                   to the Host interface methods (::evmc_host_interface).
- *                   This argument MUST NOT be NULL unless
+ * @param host       The Host interface. This argument MUST NOT be NULL unless
  *                   the @p vm has the ::EVMC_CAPABILITY_PRECOMPILES capability.
+ * @param context    The opaque pointer to the Host execution context.
+ *                   This argument MAY be NULL. The VM MUST pass the same
+ *                   pointer to the methods of the @p host interface.
+ *                   The VM MUST NOT dereference the pointer.
  * @param rev        The requested EVM specification revision.
  * @param msg        The call parameters. See ::evmc_message. This argument MUST NOT be NULL.
  * @param code       The reference to the code to be executed. This argument MAY be NULL.
@@ -802,6 +793,7 @@ enum evmc_revision
  * @return           The execution result.
  */
 typedef struct evmc_result (*evmc_execute_fn)(struct evmc_vm* vm,
+                                              const struct evmc_host_interface* host,
                                               struct evmc_host_context* context,
                                               enum evmc_revision rev,
                                               const struct evmc_message* msg,

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -587,7 +587,7 @@ public:
     /// @tparam DerivedClass  The class derived from the Host class.
     /// @param context        The opaque host context pointer.
     /// @returns              The pointer to DerivedClass.
-    template <typename DerivedClass>
+    template <typename DerivedClass = Host>
     static DerivedClass* from_context(evmc_host_context* context) noexcept
     {
         // Get pointer of the Host base class.
@@ -602,59 +602,70 @@ namespace internal
 {
 inline bool account_exists(evmc_host_context* h, const evmc_address* addr) noexcept
 {
-    return reinterpret_cast<Host*>(h)->account_exists(*addr);
+    return Host::from_context(h)->account_exists(*addr);
 }
+
 inline evmc_bytes32 get_storage(evmc_host_context* h,
                                 const evmc_address* addr,
                                 const evmc_bytes32* key) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_storage(*addr, *key);
+    return Host::from_context(h)->get_storage(*addr, *key);
 }
+
 inline evmc_storage_status set_storage(evmc_host_context* h,
                                        const evmc_address* addr,
                                        const evmc_bytes32* key,
                                        const evmc_bytes32* value) noexcept
 {
-    return reinterpret_cast<Host*>(h)->set_storage(*addr, *key, *value);
+    return Host::from_context(h)->set_storage(*addr, *key, *value);
 }
+
 inline evmc_uint256be get_balance(evmc_host_context* h, const evmc_address* addr) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_balance(*addr);
+    return Host::from_context(h)->get_balance(*addr);
 }
+
 inline size_t get_code_size(evmc_host_context* h, const evmc_address* addr) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_code_size(*addr);
+    return Host::from_context(h)->get_code_size(*addr);
 }
+
 inline evmc_bytes32 get_code_hash(evmc_host_context* h, const evmc_address* addr) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_code_hash(*addr);
+    return Host::from_context(h)->get_code_hash(*addr);
 }
+
 inline size_t copy_code(evmc_host_context* h,
                         const evmc_address* addr,
                         size_t code_offset,
                         uint8_t* buffer_data,
                         size_t buffer_size) noexcept
 {
-    return reinterpret_cast<Host*>(h)->copy_code(*addr, code_offset, buffer_data, buffer_size);
+    return Host::from_context(h)->copy_code(*addr, code_offset, buffer_data, buffer_size);
 }
+
 inline void selfdestruct(evmc_host_context* h,
                          const evmc_address* addr,
                          const evmc_address* beneficiary) noexcept
 {
-    reinterpret_cast<Host*>(h)->selfdestruct(*addr, *beneficiary);
+    Host::from_context(h)->selfdestruct(*addr, *beneficiary);
 }
+
 inline evmc_result call(evmc_host_context* h, const evmc_message* msg) noexcept
 {
-    return reinterpret_cast<Host*>(h)->call(*msg).release_raw();
+    return Host::from_context(h)->call(*msg).release_raw();
 }
+
 inline evmc_tx_context get_tx_context(evmc_host_context* h) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_tx_context();
+    return Host::from_context(h)->get_tx_context();
 }
+
 inline evmc_bytes32 get_block_hash(evmc_host_context* h, int64_t block_number) noexcept
 {
-    return reinterpret_cast<Host*>(h)->get_block_hash(block_number);
+    return Host::from_context(h)->get_block_hash(block_number);
 }
+
 inline void emit_log(evmc_host_context* h,
                      const evmc_address* addr,
                      const uint8_t* data,
@@ -662,11 +673,9 @@ inline void emit_log(evmc_host_context* h,
                      const evmc_bytes32 topics[],
                      size_t num_topics) noexcept
 {
-    reinterpret_cast<Host*>(h)->emit_log(*addr, data, data_size,
-                                         static_cast<const bytes32*>(topics), num_topics);
+    Host::from_context(h)->emit_log(*addr, data, data_size, static_cast<const bytes32*>(topics),
+                                    num_topics);
 }
-
-
 }  // namespace internal
 
 inline const evmc_host_interface* Host::get_interface() noexcept
@@ -680,8 +689,6 @@ inline const evmc_host_interface* Host::get_interface() noexcept
         ::evmc::internal::get_block_hash, ::evmc::internal::emit_log};
     return &interface;
 }
-
-
 }  // namespace evmc
 
 

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -85,13 +85,14 @@ static inline enum evmc_set_option_result evmc_set_option(struct evmc_vm* vm,
  * @see evmc_execute_fn.
  */
 static inline struct evmc_result evmc_execute(struct evmc_vm* vm,
+                                              const struct evmc_host_interface* host,
                                               struct evmc_host_context* context,
                                               enum evmc_revision rev,
                                               const struct evmc_message* msg,
                                               uint8_t const* code,
                                               size_t code_size)
 {
-    return vm->execute(vm, context, rev, msg, code, code_size);
+    return vm->execute(vm, host, context, rev, msg, code, code_size);
 }
 
 /// The evmc_result release function using free() for releasing the memory.

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -268,8 +268,8 @@ TEST(cpp, vm)
     EXPECT_EQ(vm.name(), std::string{"example_vm"});
     EXPECT_NE(vm.version()[0], 0);
 
-    auto ctx = evmc_host_context{};
-    auto res = vm.execute(ctx, EVMC_MAX_REVISION, {}, nullptr, 0);
+    const auto host = evmc_host_interface{};
+    auto res = vm.execute(host, nullptr, EVMC_MAX_REVISION, {}, nullptr, 0);
     EXPECT_EQ(res.status_code, EVMC_FAILURE);
 
     EXPECT_TRUE(vm.get_capabilities() & EVMC_CAPABILITY_EVM1);
@@ -348,8 +348,9 @@ TEST(cpp, host)
 {
     // Use example host to execute all methods from the C++ host wrapper.
 
+    auto* host_interface = example_host_get_interface();
     auto* host_context = example_host_create_context(evmc_tx_context{});
-    auto host = evmc::HostContext{host_context};
+    auto host = evmc::HostContext{host_interface, host_context};
 
     const auto a = evmc::address{{{1}}};
     const auto v = evmc::bytes32{{{7, 7, 7}}};
@@ -382,8 +383,9 @@ TEST(cpp, host_call)
 {
     // Use example host to test Host::call() method.
 
+    auto* host_interface = example_host_get_interface();
     auto* host_context = example_host_create_context(evmc_tx_context{});
-    auto host = evmc::HostContext{host_context};
+    auto host = evmc::HostContext{host_interface, host_context};
 
     EXPECT_EQ(host.call({}).gas_left, 0);
 

--- a/test/vmtester/tests.cpp
+++ b/test/vmtester/tests.cpp
@@ -59,12 +59,13 @@ TEST_F(evmc_vm_test, capabilities)
 
 TEST_F(evmc_vm_test, execute_call)
 {
+    const evmc_host_interface* host = example_host_get_interface();
     evmc_host_context* context = example_host_create_context(evmc_tx_context{});
     evmc_message msg{};
     std::array<uint8_t, 2> code = {{0xfe, 0x00}};
 
     evmc_result result =
-        vm->execute(vm, context, EVMC_MAX_REVISION, &msg, code.data(), code.size());
+        vm->execute(vm, host, context, EVMC_MAX_REVISION, &msg, code.data(), code.size());
 
     // Validate some constraints
     if (result.status_code != EVMC_SUCCESS && result.status_code != EVMC_REVERT)
@@ -92,6 +93,7 @@ TEST_F(evmc_vm_test, execute_call)
 
 TEST_F(evmc_vm_test, execute_create)
 {
+    const evmc_host_interface* host = example_host_get_interface();
     evmc_host_context* context = example_host_create_context(evmc_tx_context{});
     evmc_message msg{
         EVMC_CREATE,   0, 0, 65536, evmc_address{}, evmc_address{}, nullptr, 0, evmc_uint256be{},
@@ -99,7 +101,7 @@ TEST_F(evmc_vm_test, execute_create)
     std::array<uint8_t, 2> code = {{0xfe, 0x00}};
 
     evmc_result result =
-        vm->execute(vm, context, EVMC_MAX_REVISION, &msg, code.data(), code.size());
+        vm->execute(vm, host, context, EVMC_MAX_REVISION, &msg, code.data(), code.size());
 
     // Validate some constraints
     if (result.status_code != EVMC_SUCCESS && result.status_code != EVMC_REVERT)
@@ -181,7 +183,7 @@ TEST_F(evmc_vm_test, precompile_test)
             EVMC_CALL,     0, 0, 65536, destination, evmc_address{}, nullptr, 0, evmc_uint256be{},
             evmc_bytes32{}};
 
-        evmc_result result = vm->execute(vm, nullptr, EVMC_MAX_REVISION, &msg, nullptr, 0);
+        evmc_result result = vm->execute(vm, nullptr, nullptr, EVMC_MAX_REVISION, &msg, nullptr, 0);
 
         // Validate some constraints
 


### PR DESCRIPTION
On the C API level (and also ABI) the `host_interface` (think: an object vtable) and `host_context` (think: pointer to an object's data) are separated. This actually makes creating language bindings easier - no need for workarounds as in https://github.com/ethereum/evmc/blob/master/bindings/go/evmc/evmc.go#L26-L30.

Language bindings can still hide this by providing single OOP interface for Host (both for Client and VM side).