### PR TITLE
loader: Trim all file extensions for create function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning].
 - In `evmc::instructions` library the undefined instructions have `0` gas cost
   instead of previous `-1` value.
   [[#425](https://github.com/ethereum/evmc/pull/425)]
+- The EVMC loader trims all extensions (previously only the last one)
+  from the EVMC module file name.
+  [[#439](https://github.com/ethereum/evmc/pull/439)]
+
 
 ## [6.3.1] - 2019-08-19
 

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -152,8 +152,8 @@ evmc_create_fn evmc_load(const char* filename, enum evmc_loader_error_code* erro
     char* base_name = prefixed_name + prefix_length;
     strcpy_sx(base_name, PATH_MAX_LENGTH, name_pos);
 
-    // Trim the file extension.
-    char* ext_pos = strrchr(prefixed_name, '.');
+    // Trim all file extensions.
+    char* ext_pos = strchr(prefixed_name, '.');
     if (ext_pos)
         *ext_pos = 0;
 

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -46,7 +46,7 @@ protected:
         recorded_options.clear();
     }
 
-    void setup(const char* path, const char* symbol, evmc_create_fn fn) noexcept
+    static void setup(const char* path, const char* symbol, evmc_create_fn fn) noexcept
     {
         evmc_test_library_path = path;
         evmc_test_library_symbol = symbol;
@@ -196,6 +196,31 @@ TEST_F(loader, load_prefix_aaa)
         "unittests/libaaa.so",
         "unittests/double-prefix-aaa.evm",
         "unittests/double_prefix_aaa.evm",
+    };
+
+    const auto expected_vm_ptr = reinterpret_cast<evmc_vm*>(0xaaa);
+
+    for (auto& path : paths)
+    {
+        setup(path, "evmc_create_aaa", create_aaa);
+        evmc_loader_error_code ec;
+        const auto fn = evmc_load(path, &ec);
+        EXPECT_EQ(ec, EVMC_LOADER_SUCCESS);
+        ASSERT_TRUE(fn != nullptr);
+        EXPECT_EQ(fn(), expected_vm_ptr);
+        EXPECT_TRUE(evmc_last_error_msg() == nullptr);
+    }
+}
+
+TEST_F(loader, load_file_with_multiple_extensions)
+{
+    auto paths = {
+        "./aaa.evm.0.99",
+        "aaa.tar.gz.so",
+        "unittests/aaa.x.y.z.so",
+        "unittests/aaa.1.lib",
+        "unittests/aaa.1.0",
+        "unittests/aaa.extextextextextextextextextextextextextextextextext",
     };
 
     const auto expected_vm_ptr = reinterpret_cast<evmc_vm*>(0xaaa);


### PR DESCRIPTION
This should fix https://github.com/ethereum/evmone/pull/199 where the library file has name `libevmone.so.0.3.0`.

Fixes https://github.com/ethereum/evmc/issues/436.