### PR TITLE
loader: Simplify logic for finding create function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning].
 - The EVMC loader trims all extensions (previously only the last one)
   from the EVMC module file name.
   [[#439](https://github.com/ethereum/evmc/pull/439)]
+- The EVMC loader no longer ties to guess the VM create function name 
+  by dropping prefix words from the name.
+  [[#440](https://github.com/ethereum/evmc/pull/440)]
 
 
 ## [6.3.1] - 2019-08-19

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ commands:
             # Test statically linked end-to-end example
             ~/build/examples/evmc-example-static
             # Test dynamically loaded end-to-end example
-            ~/build/examples/evmc-example ~/build/examples/example_vm/libevmc-example-vm.so
+            ~/build/examples/evmc-example ~/build/examples/example_vm/libexample-vm.so
       - run:
           name: "Install"
           command: cmake --build ~/build --target install

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(evmc-example-host STATIC example_host.cpp)
 target_link_libraries(evmc-example-host PRIVATE evmc)
 
 add_executable(evmc-example-static example.c)
-target_link_libraries(evmc-example-static PRIVATE evmc-example-host evmc-example-vm-static evmc)
+target_link_libraries(evmc-example-static PRIVATE evmc-example-host evmc::example-vm-static evmc)
 target_compile_definitions(evmc-example-static PRIVATE STATICALLY_LINKED_EXAMPLE)
 
 add_executable(evmc-example example.c)

--- a/examples/example_precompiles_vm/CMakeLists.txt
+++ b/examples/example_precompiles_vm/CMakeLists.txt
@@ -2,13 +2,15 @@
 # Copyright 2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-add_library(evmc-example-precompiles-vm SHARED example_precompiles_vm.cpp)
-target_link_libraries(evmc-example-precompiles-vm PRIVATE evmc)
+add_library(example-precompiles-vm SHARED example_precompiles_vm.cpp)
+add_library(evmc::example-precompiles-vm ALIAS example-precompiles-vm)
+target_link_libraries(example-precompiles-vm PRIVATE evmc)
+
 set_source_files_properties(example_precompiles_vm.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 
 if(EVMC_INSTALL)
-    install(TARGETS evmc-example-precompiles-vm
+    install(TARGETS example-precompiles-vm
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/examples/example_vm/CMakeLists.txt
+++ b/examples/example_vm/CMakeLists.txt
@@ -2,17 +2,19 @@
 # Copyright 2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-add_library(evmc-example-vm SHARED example_vm.c)
-target_link_libraries(evmc-example-vm PRIVATE evmc)
+add_library(example-vm SHARED example_vm.c)
+add_library(evmc::example-vm ALIAS example-vm)
+target_link_libraries(example-vm PRIVATE evmc)
 
-add_library(evmc-example-vm-static STATIC example_vm.c)
-target_link_libraries(evmc-example-vm-static PRIVATE evmc)
+add_library(example-vm-static STATIC example_vm.c)
+add_library(evmc::example-vm-static ALIAS example-vm-static)
+target_link_libraries(example-vm-static PRIVATE evmc)
 
 set_source_files_properties(example_vm.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 
 if(EVMC_INSTALL)
-    install(TARGETS evmc-example-vm
+    install(TARGETS example-vm
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/include/evmc/loader.h
+++ b/include/evmc/loader.h
@@ -61,21 +61,16 @@ enum evmc_loader_error_code
  * After the DLL is successfully loaded the function tries to find the EVM create function in the
  * library. The `filename` is used to guess the EVM name and the name of the create function.
  * The create function name is constructed by the following rules. Consider example path:
- * "/ethereum/libexample-interpreter.so".
+ * "/ethereum/libexample-interpreter.so.1.0".
  * - the filename is taken from the path:
- *   "libexample-interpreter.so",
- * - the "lib" prefix and file extension are stripped from the name:
+ *   "libexample-interpreter.so.1.0",
+ * - the "lib" prefix and all file extensions are stripped from the name:
  *   "example-interpreter"
  * - all "-" are replaced with "_" to construct _base name_:
  *   "example_interpreter",
  * - the function name "evmc_create_" + _base name_ is searched in the library:
  *   "evmc_create_example_interpreter",
- * - if function not found, the _base name_ is shorten by skipping the first word separated by "_":
- *   "interpreter",
- * - then, the function of the shorter name "evmc_create_" + _base name_ is searched in the library:
- *   "evmc_create_interpreter",
- * - the name shortening continues until a function is found or the name cannot be shorten more,
- * - lastly, when no function found, the function name "evmc_create" is searched in the library.
+ * - if the function is not found, the function name "evmc_create" is searched in the library.
  *
  * If the create function is found in the library, the pointer to the function is returned.
  * Otherwise, the ::EVMC_LOADER_SYMBOL_NOT_FOUND error code is signaled and NULL is returned.

--- a/lib/loader/loader.c
+++ b/lib/loader/loader.c
@@ -163,15 +163,7 @@ evmc_create_fn evmc_load(const char* filename, enum evmc_loader_error_code* erro
         *dash_pos++ = '_';
 
     // Search for the built function name.
-    while ((create_fn = DLL_GET_CREATE_FN(handle, prefixed_name)) == NULL)
-    {
-        // Shorten the base name by skipping the `word_` segment.
-        const char* shorter_name_pos = strchr(base_name, '_');
-        if (!shorter_name_pos)
-            break;
-
-        memmove(base_name, shorter_name_pos + 1, strlen(shorter_name_pos) + 1);
-    }
+    create_fn = DLL_GET_CREATE_FN(handle, prefixed_name);
 
     if (!create_fn)
         create_fn = DLL_GET_CREATE_FN(handle, "evmc_create");

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(
     test_loader.cpp
 )
 
-target_link_libraries(evmc-unittests PRIVATE loader-mocked evmc-example-vm-static evmc-example-host instructions GTest::gtest_main)
+target_link_libraries(evmc-unittests PRIVATE loader-mocked evmc::example-vm-static evmc-example-host instructions GTest::gtest_main)
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 
 gtest_add_tests(TARGET evmc-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)

--- a/test/unittests/test_loader.cpp
+++ b/test/unittests/test_loader.cpp
@@ -188,14 +188,12 @@ TEST_F(loader, load_empty_path)
     EXPECT_TRUE(evmc_last_error_msg() == nullptr);
 }
 
-TEST_F(loader, load_prefix_aaa)
+TEST_F(loader, load_aaa)
 {
     auto paths = {
         "./aaa.evm",
         "aaa.evm",
         "unittests/libaaa.so",
-        "unittests/double-prefix-aaa.evm",
-        "unittests/double_prefix_aaa.evm",
     };
 
     const auto expected_vm_ptr = reinterpret_cast<evmc_vm*>(0xaaa);
@@ -285,7 +283,16 @@ TEST_F(loader, load_windows_path)
 
 TEST_F(loader, load_symbol_not_found)
 {
-    auto paths = {"libaaa1.so", "eee2.so", "libeee3.x", "eee4", "_", "lib_.so"};
+    auto paths = {
+        "libaaa1.so",
+        "eee2.so",
+        "libeee3.x",
+        "eee4",
+        "_",
+        "lib_.so",
+        "unittests/double-prefix-aaa.evm",
+        "unittests/double_prefix_aaa.evm",
+    };
 
     for (auto& path : paths)
     {

--- a/test/vmtester/CMakeLists.txt
+++ b/test/vmtester/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 
 set(prefix ${PROJECT_NAME}/vmtester)
 
-evmc_add_vm_test(NAME ${prefix}/examplevm TARGET evmc-example-vm)
-evmc_add_vm_test(NAME ${prefix}/example_precompiles_vm TARGET evmc-example-precompiles-vm)
+evmc_add_vm_test(NAME ${prefix}/examplevm TARGET example-vm)
+evmc_add_vm_test(NAME ${prefix}/example_precompiles_vm TARGET example-precompiles-vm)
 
 add_test(NAME ${prefix}/help COMMAND evmc-vmtester --version --help)
 set_tests_properties(${prefix}/help PROPERTIES PASS_REGULAR_EXPRESSION "Usage:")


### PR DESCRIPTION
The loader library no longer tries EVMC create function names with removed prefixes.