### PR TITLE
cpp: Require the host interface for HostContext be passed by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ and this project adheres to [Semantic Versioning].
   [[#442](https://github.com/ethereum/evmc/pull/442)]
 - In the Rust bindings make `ExecutionContext` optional within `execute`.
   [[#350](https://github.com/ethereum/evmc/pull/350)]
+- A set of small improvements to C++ API
+  [[#445](https://github.com/ethereum/evmc/pull/445),
+   [#449](https://github.com/ethereum/evmc/pull/449),
+   [#451](https://github.com/ethereum/evmc/pull/451)]
+   
 
 
 ## [6.3.1] - 2019-08-19

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -402,8 +402,10 @@ public:
     HostContext() = default;
 
     /// Constructor from the EVMC Host primitives.
-    HostContext(const evmc_host_interface* interface, evmc_host_context* ctx) noexcept
-      : host{interface}, context{ctx}
+    /// @param interface  The reference to the Host interface.
+    /// @param ctx        The pointer to the Host context object. This parameter MAY be null.
+    HostContext(const evmc_host_interface& interface, evmc_host_context* ctx) noexcept
+      : host{&interface}, context{ctx}
     {}
 
     bool account_exists(const address& address) noexcept final

--- a/test/unittests/test_cpp.cpp
+++ b/test/unittests/test_cpp.cpp
@@ -440,9 +440,10 @@ TEST(cpp, host)
 {
     // Use example host to execute all methods from the C++ host wrapper.
 
-    auto* host_interface = example_host_get_interface();
+    const auto* host_interface = example_host_get_interface();
+    ASSERT_NE(host_interface, nullptr);
     auto* host_context = example_host_create_context(evmc_tx_context{});
-    auto host = evmc::HostContext{host_interface, host_context};
+    auto host = evmc::HostContext{*host_interface, host_context};
 
     const auto a = evmc::address{{{1}}};
     const auto v = evmc::bytes32{{{7, 7, 7}}};
@@ -476,9 +477,10 @@ TEST(cpp, host_call)
     // Use example host to test Host::call() method.
 
     auto host = evmc::HostContext{};  // Use default constructor.
-    auto* host_interface = example_host_get_interface();
+    const auto* host_interface = example_host_get_interface();
+    ASSERT_NE(host_interface, nullptr);
     auto* host_context = example_host_create_context(evmc_tx_context{});
-    host = evmc::HostContext{host_interface, host_context};
+    host = evmc::HostContext{*host_interface, host_context};
 
     EXPECT_EQ(host.call({}).gas_left, 0);
 


### PR DESCRIPTION
Pass `evmc_host_interface` by reference to `evmc::HostContext` to make explicit that this pointer must not be null.