### PR TITLE
Fix build with clang 5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -140,6 +140,12 @@ jobs:
     steps:
       - build_and_test
 
+  build-clang5:
+    docker:
+      - image: ethereum/cpp-build-env:12-clang-5
+    steps:
+      - build_and_test
+
   build-clang38:
     docker:
       - image: ethereum/cpp-build-env:12-clang-3.8
@@ -250,6 +256,7 @@ workflows:
       - build-gcc9-cxx17-ubsan
       - build-clang9-cxx14-asan
       - build-gcc6
+      - build-clang5
       - build-clang38
       - build-gcc-32bit
       - bindings-go-latest

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -14,27 +14,27 @@ namespace evmc
 /// The string of bytes.
 using bytes = std::basic_string<uint8_t>;
 
+/// Extended value (by dirty flag) for account storage.
+struct storage_value
+{
+    /// The storage value.
+    bytes32 value;
+
+    /// True means this value has been modified already by the current transaction.
+    bool dirty{false};
+
+    /// Default constructor.
+    storage_value() noexcept = default;
+
+    /// Constructor.
+    storage_value(const bytes32& _value, bool _dirty = false) noexcept  // NOLINT
+      : value{_value}, dirty{_dirty}
+    {}
+};
+
 /// Mocked account.
 struct MockedAccount
 {
-    /// Extended value (by dirty flag) for account storage.
-    struct storage_value
-    {
-        /// The storage value.
-        bytes32 value;
-
-        /// True means this value has been modified already by the current transaction.
-        bool dirty{false};
-
-        /// Default constructor.
-        storage_value() noexcept = default;
-
-        /// Constructor.
-        storage_value(const bytes32& _value, bool _dirty = false) noexcept  // NOLINT
-          : value{_value}, dirty{_dirty}
-        {}
-    };
-
     /// The account nonce.
     int nonce = 0;
 


### PR DESCRIPTION
This simply moves `storage_value` struct out of `MockedAccount` struct. Fix is a workaround for a clang 5 compiler bug.

Fixes #467.