### PR TITLE
CMake improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning].
 - In the Rust bindings added more type aliases (`MessageKind`, `MessageFlags`, `StatusCode`,
   `StorageStatus`, `Revision`).
   [#206](https://github.com/ethereum/evmc/pull/206)
+- In CMake the `evmc::evmc_cpp` target has been added which represents the C++ EVMC API.
+  [#470](https://github.com/ethereum/evmc/pull/470)
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ cable_configure_compiler(NO_STACK_PROTECTION)
 
 set(include_dir ${PROJECT_SOURCE_DIR}/include)
 
-add_library(evmc INTERFACE)
-add_library(evmc::evmc ALIAS evmc)
-target_include_directories(evmc INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
-
 add_subdirectory(lib)
 
 if(EVMC_TOOLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,6 @@ configure_package_config_file(
 )
 
 if(EVMC_INSTALL)
-    install(TARGETS evmc EXPORT evmcTargets)
     install(DIRECTORY include/evmc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
     install(

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,12 +4,6 @@
 
 include(GNUInstallDirs)
 
-if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-set(CMAKE_DEBUG_POSTFIX "")
-
 add_subdirectory(example_vm)
 add_subdirectory(example_precompiles_vm)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,11 +8,11 @@ add_subdirectory(example_vm)
 add_subdirectory(example_precompiles_vm)
 
 add_library(evmc-example-host STATIC example_host.cpp)
-target_link_libraries(evmc-example-host PRIVATE evmc)
+target_link_libraries(evmc-example-host PRIVATE evmc::evmc_cpp)
 
 add_executable(evmc-example-static example.c)
-target_link_libraries(evmc-example-static PRIVATE evmc-example-host evmc::example-vm-static evmc)
+target_link_libraries(evmc-example-static PRIVATE evmc-example-host evmc::example-vm-static evmc::evmc)
 target_compile_definitions(evmc-example-static PRIVATE STATICALLY_LINKED_EXAMPLE)
 
 add_executable(evmc-example example.c)
-target_link_libraries(evmc-example PRIVATE evmc-example-host evmc evmc::loader)
+target_link_libraries(evmc-example PRIVATE evmc-example-host evmc::loader)

--- a/examples/example_precompiles_vm/CMakeLists.txt
+++ b/examples/example_precompiles_vm/CMakeLists.txt
@@ -4,11 +4,11 @@
 
 add_library(example-precompiles-vm SHARED example_precompiles_vm.cpp example_precompiles_vm.h)
 add_library(evmc::example-precompiles-vm ALIAS example-precompiles-vm)
-target_link_libraries(example-precompiles-vm PRIVATE evmc)
+target_link_libraries(example-precompiles-vm PRIVATE evmc::evmc)
 
 add_library(example-precompiles-vm-static STATIC example_precompiles_vm.cpp example_precompiles_vm.h)
 add_library(evmc::example-precompiles-vm-static ALIAS example-precompiles-vm-static)
-target_link_libraries(example-precompiles-vm-static PRIVATE evmc)
+target_link_libraries(example-precompiles-vm-static PRIVATE evmc::evmc)
 
 set_source_files_properties(example_precompiles_vm.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")

--- a/examples/example_vm/CMakeLists.txt
+++ b/examples/example_vm/CMakeLists.txt
@@ -4,11 +4,11 @@
 
 add_library(example-vm SHARED example_vm.c example_vm.h)
 add_library(evmc::example-vm ALIAS example-vm)
-target_link_libraries(example-vm PRIVATE evmc)
+target_link_libraries(example-vm PRIVATE evmc::evmc)
 
 add_library(example-vm-static STATIC example_vm.c example_vm.h)
 add_library(evmc::example-vm-static ALIAS example-vm-static)
-target_link_libraries(example-vm-static PRIVATE evmc)
+target_link_libraries(example-vm-static PRIVATE evmc::evmc)
 
 set_source_files_properties(example_vm.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,15 @@ add_library(evmc INTERFACE)
 add_library(evmc::evmc ALIAS evmc)
 target_include_directories(evmc INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
 
+add_library(evmc_cpp INTERFACE)
+add_library(evmc::evmc_cpp ALIAS evmc_cpp)
+target_include_directories(evmc_cpp INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
+target_link_libraries(evmc_cpp INTERFACE evmc::evmc)
+
 add_subdirectory(instructions)
 add_subdirectory(loader)
 add_subdirectory(mocked_host)
+
+if(EVMC_INSTALL)
+    install(TARGETS evmc evmc_cpp EXPORT evmcTargets)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,6 +2,10 @@
 # Copyright 2018-2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
+add_library(evmc INTERFACE)
+add_library(evmc::evmc ALIAS evmc)
+target_include_directories(evmc INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
+
 add_subdirectory(instructions)
 add_subdirectory(loader)
 add_subdirectory(mocked_host)

--- a/lib/instructions/CMakeLists.txt
+++ b/lib/instructions/CMakeLists.txt
@@ -10,8 +10,13 @@ add_library(
 )
 
 add_library(evmc::instructions ALIAS instructions)
-set_target_properties(instructions PROPERTIES OUTPUT_NAME evmc-instructions)
-target_include_directories(instructions PUBLIC $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
+set_target_properties(instructions PROPERTIES
+    OUTPUT_NAME evmc-instructions
+    POSITION_INDEPENDENT_CODE TRUE
+)
+target_include_directories(instructions PUBLIC
+    $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>
+)
 
 if(EVMC_INSTALL)
     install(TARGETS instructions EXPORT evmcTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/lib/loader/CMakeLists.txt
+++ b/lib/loader/CMakeLists.txt
@@ -13,10 +13,7 @@ set_target_properties(loader PROPERTIES
     OUTPUT_NAME evmc-loader
     POSITION_INDEPENDENT_CODE TRUE
 )
-target_include_directories(loader PUBLIC
-    $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-target_link_libraries(loader INTERFACE ${CMAKE_DL_LIBS})
+target_link_libraries(loader INTERFACE ${CMAKE_DL_LIBS} PUBLIC evmc::evmc)
 
 if(EVMC_INSTALL)
     install(TARGETS loader EXPORT evmcTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/lib/mocked_host/CMakeLists.txt
+++ b/lib/mocked_host/CMakeLists.txt
@@ -6,9 +6,7 @@ add_library(mocked_host INTERFACE)
 target_sources(mocked_host INTERFACE $<BUILD_INTERFACE:${include_dir}/evmc/mocked_host.hpp>)
 
 add_library(evmc::mocked_host ALIAS mocked_host)
-target_include_directories(mocked_host INTERFACE
-    $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+target_link_libraries(mocked_host INTERFACE evmc::evmc_cpp)
 
 if(EVMC_INSTALL)
     install(TARGETS mocked_host EXPORT evmcTargets)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(GTest CONFIG REQUIRED)
 set_target_properties(GTest::gtest PROPERTIES INTERFACE_COMPILE_DEFINITIONS GTEST_HAS_TR1_TUPLE=0)
 
 add_library(loader-mocked STATIC ${PROJECT_SOURCE_DIR}/lib/loader/loader.c)
-target_link_libraries(loader-mocked PRIVATE evmc)
+target_link_libraries(loader-mocked PRIVATE evmc::evmc)
 target_compile_definitions(loader-mocked PRIVATE EVMC_LOADER_MOCK=1)
 
 add_executable(


### PR DESCRIPTION
This mostly adds `evmc::evmc_cpp` target representing C++ headers. It also contains some dependency cleanups.