### PR TITLE
CMake improvements 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,8 @@ endif()
 include(cmake/cable/bootstrap.cmake)
 include(CableBuildType)
 include(CableCompilerSettings)
-include(CMakeDependentOption)
 include(CablePackage)
-include(CableToolchains)
+include(CMakeDependentOption)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
@@ -41,7 +40,6 @@ if(HUNTER_ENABLED)
     include(defaults/HunterCacheServers)
 endif()
 
-cable_configure_toolchain(DEFAULT cxx11-pic)
 cable_set_build_type(DEFAULT Release CONFIGURATION_TYPES Debug Release)
 
 project(evmc)

--- a/circle.yml
+++ b/circle.yml
@@ -153,7 +153,7 @@ jobs:
     docker:
       - image: ethereum/cpp-build-env:12-gcc-8
     environment:
-      CMAKE_OPTIONS: -DTOOLCHAIN=cxx17-pic
+      CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=17
     steps:
       - build_and_test
 
@@ -161,7 +161,7 @@ jobs:
     docker:
       - image: ethereum/cpp-build-env:12-gcc-9
     environment:
-      CMAKE_OPTIONS: -DTOOLCHAIN=cxx17-pic -DSANITIZE=undefined
+      CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=17 -DSANITIZE=undefined
     steps:
       - build_and_test
 
@@ -169,7 +169,7 @@ jobs:
     docker:
       - image: ethereum/cpp-build-env:12-clang-9
     environment:
-      CMAKE_OPTIONS: -DTOOLCHAIN=cxx14-pic -DSANITIZE=address
+      CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=14 -DSANITIZE=address
       UBSAN_OPTIONS: halt_on_error=1
     steps:
       - build_and_test
@@ -196,7 +196,7 @@ jobs:
     docker:
       - image: ethereum/cpp-build-env:12-base
     environment:
-      CMAKE_OPTIONS: -DTOOLCHAIN=cxx11-32bit
+      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/cable/toolchains/cxx11-32bit.cmake
     steps:
       - run:
           name: "Install GCC 32-bit"

--- a/examples/example_precompiles_vm/CMakeLists.txt
+++ b/examples/example_precompiles_vm/CMakeLists.txt
@@ -4,10 +4,12 @@
 
 add_library(example-precompiles-vm SHARED example_precompiles_vm.cpp example_precompiles_vm.h)
 add_library(evmc::example-precompiles-vm ALIAS example-precompiles-vm)
+target_compile_features(example-precompiles-vm PRIVATE cxx_std_11)
 target_link_libraries(example-precompiles-vm PRIVATE evmc::evmc)
 
 add_library(example-precompiles-vm-static STATIC example_precompiles_vm.cpp example_precompiles_vm.h)
 add_library(evmc::example-precompiles-vm-static ALIAS example-precompiles-vm-static)
+target_compile_features(example-precompiles-vm-static PRIVATE cxx_std_11)
 target_link_libraries(example-precompiles-vm-static PRIVATE evmc::evmc)
 
 set_source_files_properties(example_precompiles_vm.cpp PROPERTIES

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(evmc INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INS
 
 add_library(evmc_cpp INTERFACE)
 add_library(evmc::evmc_cpp ALIAS evmc_cpp)
+target_compile_features(evmc_cpp INTERFACE cxx_std_11)
 target_include_directories(evmc_cpp INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
 target_link_libraries(evmc_cpp INTERFACE evmc::evmc)
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
     evmc::example-vm-static
     evmc::example-precompiles-vm-static
     evmc::instructions
+    evmc::evmc_cpp
     GTest::gtest_main
 )
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)


### PR DESCRIPTION
This removes mandatory usage of CMake toolchain files. Instead it is now specified that C++ libraries require C++11, but the C++ standard is not forced.