### PR TITLE
rust: version dependencies

### DIFF
--- a/bindings/rust/evmc-declare/Cargo.toml
+++ b/bindings/rust/evmc-declare/Cargo.toml
@@ -17,7 +17,7 @@ heck = "0.3.1"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full"] }
 # For documentation examples
-evmc-vm = { path = "../evmc-vm" }
+evmc-vm = { path = "../evmc-vm", version = "7.2.0-alpha.0" }
 
 [lib]
 proc-macro = true

--- a/bindings/rust/evmc-vm/Cargo.toml
+++ b/bindings/rust/evmc-vm/Cargo.toml
@@ -12,4 +12,4 @@ description = "Bindings to EVMC (VM specific)"
 edition = "2018"
 
 [dependencies]
-evmc-sys = { path = "../evmc-sys" }
+evmc-sys = { path = "../evmc-sys", version = "7.2.0-alpha.0" }


### PR DESCRIPTION
Closes #475.

This is needed to publish the crates.