### PR TITLE
EVMC runner tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
-- Added Java bindings.
+- Added **Java** bindings.
   [#455](https://github.com/ethereum/evmc/pull/455)
 - The C++ EVMC basic types `address` and `bytes32` have all the comparison operators supported.
   [#474](https://github.com/ethereum/evmc/pull/474)
+- New **evmc command-line tool** has been added. At the moment it supports
+  command _run_ for executing bytecode in any EVMC-compatible VM implementation.
+  Try `evmc run --help` for more information.
 
 
 ## [7.1.0] — 2019-11-29

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0.
 
 cmake_minimum_required(VERSION 3.5)
+cmake_policy(SET CMP0074 NEW)
 
 if(TARGET evmc)
     # The evmc library has been already created (probably by other submodule).

--- a/circle.yml
+++ b/circle.yml
@@ -135,6 +135,7 @@ jobs:
               -object bin/evmc-vmtester
             llvm-cov export -instr-profile evmc.profdata -format=lcov > evmc.lcov \
               -object test/evmc-unittests \
+              -object bin/evmc \
               -object bin/evmc-vmtester
             genhtml evmc.lcov -o coverage -t EVMC
       - store_artifacts:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,10 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project: no
+    patch: no
+
 comment:
   layout: "diff"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,5 +4,6 @@
 
 add_subdirectory(cmake_package)
 add_subdirectory(compilation)
+add_subdirectory(tools)
 add_subdirectory(unittests)
 add_subdirectory(vmtester)

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -12,3 +12,6 @@ set_tests_properties(
     ${prefix}/example1 PROPERTIES PASS_REGULAR_EXPRESSION
     "Result: +success[\r\n]+Gas used: +99[\r\n]+Output: +0000000000000000000000000000000000000000[\r\n]"
 )
+
+get_property(tools_tests DIRECTORY PROPERTY TESTS)
+set_tests_properties(${tools_tests} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/tools-%p.profraw)

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,0 +1,14 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+set(prefix ${PROJECT_NAME}/evmc-run)
+
+add_test(
+    NAME ${prefix}/example1
+    COMMAND evmc::tool run --vm $<TARGET_FILE:evmc::example-vm> 30600052596000f3 --gas 99
+)
+set_tests_properties(
+    ${prefix}/example1 PROPERTIES PASS_REGULAR_EXPRESSION
+    "Result: +success[\r\n]+Gas used: +99[\r\n]+Output: +0000000000000000000000000000000000000000[\r\n]"
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,4 +2,5 @@
 # Copyright 2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
+add_subdirectory(evmc)
 add_subdirectory(vmtester)

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -6,6 +6,7 @@ hunter_add_package(CLI11)
 find_package(CLI11 REQUIRED)
 
 add_executable(evmc-tool main.cpp utils.cpp utils.hpp)
+add_executable(evmc::tool ALIAS evmc-tool)
 set_target_properties(evmc-tool PROPERTIES
     OUTPUT_NAME evmc
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -5,7 +5,7 @@
 hunter_add_package(CLI11)
 find_package(CLI11 REQUIRED)
 
-add_executable(evmc-tool main.cpp)
+add_executable(evmc-tool main.cpp utils.cpp utils.hpp)
 set_target_properties(evmc-tool PROPERTIES
     OUTPUT_NAME evmc
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -11,4 +11,4 @@ set_target_properties(evmc-tool PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set_source_files_properties(main.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
-target_link_libraries(evmc-tool PRIVATE CLI11::CLI11)
+target_link_libraries(evmc-tool PRIVATE evmc::mocked_host evmc::loader CLI11::CLI11)

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -1,0 +1,14 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2019 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+hunter_add_package(CLI11)
+find_package(CLI11 REQUIRED)
+
+add_executable(evmc-tool main.cpp)
+set_target_properties(evmc-tool PROPERTIES
+    OUTPUT_NAME evmc
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set_source_files_properties(main.cpp PROPERTIES
+    COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
+target_link_libraries(evmc-tool PRIVATE CLI11::CLI11)

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -17,9 +17,14 @@ int main(int argc, const char** argv)
 
     std::string vm_config;
     std::string code_hex;
+    evmc_message msg{};
+    msg.gas = 1000000;
+
     auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
-    run_cmd.add_option("--vm", vm_config)->required();
-    run_cmd.add_option("code", code_hex)->required();
+    run_cmd.add_option("code", code_hex, "Hex-encoded bytecode")->required();
+    run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required();
+    run_cmd.add_option("--gas", msg.gas, "Execution gas limit", true)
+        ->check(CLI::Range(0, 1000000000));
 
     try
     {
@@ -49,8 +54,6 @@ int main(int argc, const char** argv)
             }
 
             MockedHost host;
-            evmc_message msg{};
-            msg.gas = 10000000;
 
             std::cout << "Executing on Istanbul with " << msg.gas << " gas limit\n"
                       << "in " << vm_config << "\n";

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -3,11 +3,23 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include <CLI/CLI.hpp>
+#include <evmc/loader.h>
+#include <evmc/mocked_host.hpp>
+
+#include "utils.hpp"
 
 int main(int argc, const char** argv)
 {
+    using namespace evmc;
+
     CLI::App app{"EVMC tool"};
     const auto& version_flag = *app.add_flag("--version", "Print version information");
+
+    std::string vm_config;
+    std::string code_hex;
+    auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
+    run_cmd.add_option("--vm", vm_config)->required();
+    run_cmd.add_option("code", code_hex)->required();
 
     try
     {
@@ -20,14 +32,53 @@ int main(int argc, const char** argv)
             return 0;
         }
 
+        if (run_cmd)
+        {
+            const auto code = from_hex(code_hex);
+
+            evmc_loader_error_code ec;
+            auto vm = VM{evmc_load_and_configure(vm_config.c_str(), &ec)};
+            if (ec != EVMC_LOADER_SUCCESS)
+            {
+                const auto error = evmc_last_error_msg();
+                if (error != nullptr)
+                    std::cerr << error << "\n";
+                else
+                    std::cerr << "Loading error " << ec << "\n";
+                return static_cast<int>(ec);
+            }
+
+            MockedHost host;
+            evmc_message msg{};
+            msg.gas = 10000000;
+
+            std::cout << "Executing on Istanbul with " << msg.gas << " gas limit\n"
+                      << "in " << vm_config << "\n";
+            const auto result = vm.execute(host, EVMC_ISTANBUL, msg, code.data(), code.size());
+
+            const auto gas_used = msg.gas - result.gas_left;
+
+            std::cout << "\nResult:   " << result.status_code << "\nGas used: " << gas_used << "\n";
+
+            if (result.status_code == EVMC_SUCCESS || result.status_code == EVMC_REVERT)
+                std::cout << "Output:   " << hex(result.output_data, result.output_size) << "\n";
+
+            return 0;
+        }
+
         return 0;
     }
     catch (const CLI::ParseError& e)
     {
         return app.exit(e);
     }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error: " << e.what() << "\n";
+        return -1;
+    }
     catch (...)
     {
-        return -1;
+        return -2;
     }
 }

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -1,0 +1,33 @@
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2019 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include <CLI/CLI.hpp>
+
+int main(int argc, const char** argv)
+{
+    CLI::App app{"EVMC tool"};
+    const auto& version_flag = *app.add_flag("--version", "Print version information");
+
+    try
+    {
+        app.parse(argc, argv);
+
+        // Handle the --version flag first and exit when present.
+        if (version_flag)
+        {
+            std::cout << "EVMC tool " PROJECT_VERSION "\n";
+            return 0;
+        }
+
+        return 0;
+    }
+    catch (const CLI::ParseError& e)
+    {
+        return app.exit(e);
+    }
+    catch (...)
+    {
+        return -1;
+    }
+}

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, const char** argv)
 
     auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
     run_cmd.add_option("code", code_hex, "Hex-encoded bytecode")->required();
-    run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required();
+    run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required()->envname("EVMC_VM");
     run_cmd.add_option("--gas", msg.gas, "Execution gas limit", true)
         ->check(CLI::Range(0, 1000000000));
 

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -19,12 +19,14 @@ int main(int argc, const char** argv)
     std::string code_hex;
     evmc_message msg{};
     msg.gas = 1000000;
+    auto rev = EVMC_ISTANBUL;
 
     auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
     run_cmd.add_option("code", code_hex, "Hex-encoded bytecode")->required();
     run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required()->envname("EVMC_VM");
     run_cmd.add_option("--gas", msg.gas, "Execution gas limit", true)
         ->check(CLI::Range(0, 1000000000));
+    run_cmd.add_option("--rev", rev, "EVM revision", true);
 
     try
     {
@@ -55,9 +57,9 @@ int main(int argc, const char** argv)
 
             MockedHost host;
 
-            std::cout << "Executing on Istanbul with " << msg.gas << " gas limit\n"
+            std::cout << "Executing on " << rev << " with " << msg.gas << " gas limit\n"
                       << "in " << vm_config << "\n";
-            const auto result = vm.execute(host, EVMC_ISTANBUL, msg, code.data(), code.size());
+            const auto result = vm.execute(host, rev, msg, code.data(), code.size());
 
             const auto gas_used = msg.gas - result.gas_left;
 

--- a/tools/evmc/utils.cpp
+++ b/tools/evmc/utils.cpp
@@ -1,0 +1,48 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2018-2019 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include "utils.hpp"
+#include <stdexcept>
+
+namespace evmc
+{
+bytes from_hex(const std::string& hex)
+{
+    if (hex.length() % 2 == 1)
+        throw std::length_error{"the length of the input is odd"};
+
+    bytes bs;
+    bs.reserve(hex.length() / 2);
+    int b = 0;
+    for (size_t i = 0; i < hex.size(); ++i)
+    {
+        const auto h = hex[i];
+        int v;
+        if (h >= '0' && h <= '9')
+            v = h - '0';
+        else if (h >= 'a' && h <= 'f')
+            v = h - 'a' + 10;
+        else if (h >= 'A' && h <= 'F')
+            v = h - 'A' + 10;
+        else
+            throw std::out_of_range{"not a hex digit"};
+
+        if (i % 2 == 0)
+            b = v << 4;
+        else
+            bs.push_back(static_cast<uint8_t>(b | v));
+    }
+    return bs;
+}
+
+std::string hex(const uint8_t* data, size_t size)
+{
+    std::string str;
+    str.reserve(size * 2);
+    for (const auto end = data + size; data != end; ++data)
+        str += hex(*data);
+    return str;
+}
+
+}  // namespace evmc

--- a/tools/evmc/utils.cpp
+++ b/tools/evmc/utils.cpp
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include "utils.hpp"
+#include <ostream>
 #include <stdexcept>
 
 namespace evmc
@@ -43,6 +44,77 @@ std::string hex(const uint8_t* data, size_t size)
     for (const auto end = data + size; data != end; ++data)
         str += hex(*data);
     return str;
+}
+
+std::ostream& operator<<(std::ostream& os, evmc_status_code status_code)
+{
+    const char* s = nullptr;
+    switch (status_code)
+    {
+    case EVMC_SUCCESS:
+        s = "success";
+        break;
+    case EVMC_FAILURE:
+        s = "failure";
+        break;
+    case EVMC_REVERT:
+        s = "revert";
+        break;
+    case EVMC_OUT_OF_GAS:
+        s = "out of gas";
+        break;
+    case EVMC_INVALID_INSTRUCTION:
+        s = "invalid instruction";
+        break;
+    case EVMC_UNDEFINED_INSTRUCTION:
+        s = "undefined instruction";
+        break;
+    case EVMC_STACK_OVERFLOW:
+        s = "stack overflow";
+        break;
+    case EVMC_STACK_UNDERFLOW:
+        s = "stack underflow";
+        break;
+    case EVMC_BAD_JUMP_DESTINATION:
+        s = "bad jump destination";
+        break;
+    case EVMC_INVALID_MEMORY_ACCESS:
+        s = "invalid memory access";
+        break;
+    case EVMC_CALL_DEPTH_EXCEEDED:
+        s = "call depth exceeded";
+        break;
+    case EVMC_STATIC_MODE_VIOLATION:
+        s = "static mode violation";
+        break;
+    case EVMC_PRECOMPILE_FAILURE:
+        s = "precompile failure";
+        break;
+    case EVMC_CONTRACT_VALIDATION_FAILURE:
+        s = "contract validation failure";
+        break;
+    case EVMC_ARGUMENT_OUT_OF_RANGE:
+        s = "argument out of range";
+        break;
+    case EVMC_WASM_UNREACHABLE_INSTRUCTION:
+        s = "wasm unreachable instruction";
+        break;
+    case EVMC_WASM_TRAP:
+        s = "wasm trap";
+        break;
+    case EVMC_INTERNAL_ERROR:
+        s = "internal error";
+        break;
+    case EVMC_REJECTED:
+        s = "rejected";
+        break;
+    case EVMC_OUT_OF_MEMORY:
+        s = "out of memory";
+        break;
+    default:
+        throw std::invalid_argument{"invalid EVMC status code: " + std::to_string(status_code)};
+    }
+    return os << s;
 }
 
 }  // namespace evmc

--- a/tools/evmc/utils.cpp
+++ b/tools/evmc/utils.cpp
@@ -117,4 +117,42 @@ std::ostream& operator<<(std::ostream& os, evmc_status_code status_code)
     return os << s;
 }
 
+std::ostream& operator<<(std::ostream& os, evmc_revision revision)
+{
+    const char* s = nullptr;
+    switch (revision)
+    {
+    case EVMC_FRONTIER:
+        s = "Frontier";
+        break;
+    case EVMC_HOMESTEAD:
+        s = "Homestead";
+        break;
+    case EVMC_TANGERINE_WHISTLE:
+        s = "Tangerine Whistle";
+        break;
+    case EVMC_SPURIOUS_DRAGON:
+        s = "Spurious Dragon";
+        break;
+    case EVMC_BYZANTIUM:
+        s = "Byzantium";
+        break;
+    case EVMC_CONSTANTINOPLE:
+        s = "Constantinople";
+        break;
+    case EVMC_PETERSBURG:
+        s = "Petersburg";
+        break;
+    case EVMC_ISTANBUL:
+        s = "Istanbul";
+        break;
+    case EVMC_BERLIN:
+        s = "Berlin";
+        break;
+    default:
+        throw std::invalid_argument{"invalid EVM revision: " + std::to_string(revision)};
+    }
+    return os << s;
+}
+
 }  // namespace evmc

--- a/tools/evmc/utils.hpp
+++ b/tools/evmc/utils.hpp
@@ -33,4 +33,7 @@ std::string hex(const uint8_t* data, size_t size);
 /// Output stream operator for evmc_status_code.
 std::ostream& operator<<(std::ostream& os, evmc_status_code status_code);
 
+/// Output stream operator for EVM revision.
+std::ostream& operator<<(std::ostream& os, evmc_revision revision);
+
 }  // namespace evmc

--- a/tools/evmc/utils.hpp
+++ b/tools/evmc/utils.hpp
@@ -1,0 +1,30 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2018-2019 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace evmc
+{
+using bytes = std::basic_string<uint8_t>;
+
+/// Encode a byte to a hex string.
+inline std::string hex(uint8_t b) noexcept
+{
+    static constexpr auto hex_chars = "0123456789abcdef";
+    return {hex_chars[b >> 4], hex_chars[b & 0xf]};
+}
+
+/// Decodes hex encoded string to bytes.
+///
+/// Exceptions:
+/// - std::length_error when the input has invalid length (must be even).
+/// - std::out_of_range when invalid hex digit encountered.
+bytes from_hex(const std::string& hex);
+
+/// Encodes bytes as hex string.
+std::string hex(const uint8_t* data, size_t size);
+
+}  // namespace evmc

--- a/tools/evmc/utils.hpp
+++ b/tools/evmc/utils.hpp
@@ -3,7 +3,9 @@
 // Licensed under the Apache License, Version 2.0.
 #pragma once
 
+#include <evmc/evmc.h>
 #include <cstdint>
+#include <iosfwd>
 #include <string>
 
 namespace evmc
@@ -26,5 +28,9 @@ bytes from_hex(const std::string& hex);
 
 /// Encodes bytes as hex string.
 std::string hex(const uint8_t* data, size_t size);
+
+
+/// Output stream operator for evmc_status_code.
+std::ostream& operator<<(std::ostream& os, evmc_status_code status_code);
 
 }  // namespace evmc


### PR DESCRIPTION
A first version of the EVMC runner tool.

1. We want a single tool `evmc` with subcommands. This one adds the main tool with `run` command.
2. Later we will move the `evmc-vmtester` here probably as `evmc check-vm`.
3. This uses CLI11 library for parsing command line options.
4. I tried to move the `run` command to separate file, but it gets messy a bit. We may try it later, but this might not be good idea in general. Moreover, building every file including `CLI.hpp` takes ~2s.
5. We should move hex helpers from evmone here. But C++17 would be nice for it to have `string_view`. There is a way to specify that only some CMake targets require C++17.

Closes #447.