### PR TITLE
Coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ project(evmc)
 set(PROJECT_VERSION 7.2.0-alpha.0)
 
 cable_configure_compiler(NO_STACK_PROTECTION)
+if(CABLE_COMPILER_CLANG)
+    set(CMAKE_C_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
+    set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
+elseif(CABLE_COMPILER_GNU)
+    set(CMAKE_C_FLAGS_COVERAGE "--coverage")
+    set(CMAKE_CXX_FLAGS_COVERAGE "--coverage")
+endif()
 
 set(include_dir ${PROJECT_SOURCE_DIR}/include)
 

--- a/circle.yml
+++ b/circle.yml
@@ -109,6 +109,45 @@ jobs:
             git commit -m "Update docs"
             git push -f "https://$GITHUB_TOKEN@github.com/ethereum/evmc.git" HEAD:gh-pages
 
+  build-clang9-coverage:
+    docker:
+      - image: ethereum/cpp-build-env:12-clang-9
+    environment:
+      CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Coverage
+    steps:
+      - run:
+          name: "Install lcov"
+          working_directory: /tmp
+          command: |
+            sudo apt-get -q update
+            # sudo apt-get install -qy lcov --no-install-recommends
+            apt-get download lcov
+            sudo dpkg -i --force-depends lcov*.deb
+      - build_and_test
+      - run:
+          name: "Collect coverage data"
+          working_directory: ~/build
+          command: |
+            find -name '*.profraw'
+            llvm-profdata merge *.profraw -o evmc.profdata
+            llvm-cov report -instr-profile evmc.profdata \
+              -object test/evmc-unittests \
+              -object bin/evmc-vmtester
+            llvm-cov export -instr-profile evmc.profdata -format=lcov > evmc.lcov \
+              -object test/evmc-unittests \
+              -object bin/evmc-vmtester
+            genhtml evmc.lcov -o coverage -t EVMC
+      - store_artifacts:
+          path: ~/build/coverage
+          destination: coverage
+      - run:
+          name: "Upload to Codecov"
+          command: |
+            # Convert to relative paths
+            sed -i 's|$(pwd)/||' ~/build/evmc.lcov
+            codecov --file ~/build/evmc.lcov -X gcov
+
+
   build-gcc8-cxx17:
     docker:
       - image: ethereum/cpp-build-env:12-gcc-8
@@ -271,6 +310,7 @@ workflows:
   evmc:
     jobs:
       - lint
+      - build-clang9-coverage
       - build-gcc8-cxx17
       - build-gcc9-cxx17-ubsan
       - build-clang9-cxx14-asan

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  layout: "diff"

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -35,4 +35,6 @@ target_link_libraries(
 )
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 
-gtest_add_tests(TARGET evmc-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)
+gtest_add_tests(TARGET evmc-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/ TEST_LIST unittests)
+
+set_tests_properties(${unittests} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/unittests-%p.profraw)

--- a/test/vmtester/CMakeLists.txt
+++ b/test/vmtester/CMakeLists.txt
@@ -29,3 +29,6 @@ set_tests_properties(${prefix}/unknown-option PROPERTIES PASS_REGULAR_EXPRESSION
 
 add_test(NAME ${prefix}/option-long-prefix COMMAND evmc::evmc-vmtester ---)
 set_tests_properties(${prefix}/option-long-prefix PROPERTIES PASS_REGULAR_EXPRESSION "Unknown")
+
+get_property(vmtester_tests DIRECTORY PROPERTY TESTS)
+set_tests_properties(${vmtester_tests} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/vmtester-%p.profraw)


### PR DESCRIPTION
This creates LCOV code coverage report using clang AST-based coverage tools. The report is visible at CircleCI as artifact: https://20298-66214407-gh.circle-artifacts.com/0/coverage/index.html
The same report is also send to codecov.