### PR TITLE
cmake: Bump minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@
 # Licensed under the Apache License, Version 2.0.
 
 cmake_minimum_required(VERSION 3.5)
-cmake_policy(SET CMP0074 NEW)
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
 
 if(TARGET evmc)
     # The evmc library has been already created (probably by other submodule).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2016-2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 if(POLICY CMP0074)
     cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
- We are using GoogleTest module introduced in 3.9.
- None of Debian / Ubuntu distributions versions provides CMake 3.9. The 3.10 is selected because this is the version provided in Ubuntu 18.04 LTS.