### PR TITLE
fix less compare for address and bytes32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning].
 - New **evmc command-line tool** has been added. At the moment it supports
   command _run_ for executing bytecode in any EVMC-compatible VM implementation.
   Try `evmc run --help` for more information.
+  
+### Fixed
+
+- The implementation of C++ `operator<` for `evmc::address` and `evmc::bytes32` has been fixed.
+  [#498](https://github.com/ethereum/evmc/pull/498)
 
 
 ## [7.1.0] — 2019-11-29

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -161,9 +161,9 @@ constexpr bool operator<(const address& a, const address& b) noexcept
 {
     return load64be(&a.bytes[0]) < load64be(&b.bytes[0]) ||
            (load64be(&a.bytes[0]) == load64be(&b.bytes[0]) &&
-            load64be(&a.bytes[8]) < load64be(&b.bytes[8])) ||
-           (load64be(&a.bytes[8]) == load64be(&b.bytes[8]) &&
-            load32be(&a.bytes[16]) < load32be(&b.bytes[16]));
+            (load64be(&a.bytes[8]) < load64be(&b.bytes[8]) ||
+             (load64be(&a.bytes[8]) == load64be(&b.bytes[8]) &&
+              load32be(&a.bytes[16]) < load32be(&b.bytes[16]))));
 }
 
 /// The "greater than" comparison operator for the evmc::address type.
@@ -204,11 +204,11 @@ constexpr bool operator<(const bytes32& a, const bytes32& b) noexcept
 {
     return load64be(&a.bytes[0]) < load64be(&b.bytes[0]) ||
            (load64be(&a.bytes[0]) == load64be(&b.bytes[0]) &&
-            load64be(&a.bytes[8]) < load64be(&b.bytes[8])) ||
-           (load64be(&a.bytes[8]) == load64be(&b.bytes[8]) &&
-            load64be(&a.bytes[16]) < load64be(&b.bytes[16])) ||
-           (load64be(&a.bytes[16]) == load64be(&b.bytes[16]) &&
-            load64be(&a.bytes[24]) < load64be(&b.bytes[24]));
+            (load64be(&a.bytes[8]) < load64be(&b.bytes[8]) ||
+             (load64be(&a.bytes[8]) == load64be(&b.bytes[8]) &&
+              (load64be(&a.bytes[16]) < load64be(&b.bytes[16]) ||
+               (load64be(&a.bytes[16]) == load64be(&b.bytes[16]) &&
+                load64be(&a.bytes[24]) < load64be(&b.bytes[24]))))));
 }
 
 /// The "greater than" comparison operator for the evmc::bytes32 type.

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -223,10 +223,17 @@ TEST(cpp, address_comparison)
     auto max = evmc::address{};
     std::fill_n(max.bytes, sizeof(max), uint8_t{0xff});
 
+    auto zero_max = evmc::address{};
+    std::fill_n(zero_max.bytes + 8, sizeof(zero_max) - 8, uint8_t{0xff});
+    auto max_zero = evmc::address{};
+    std::fill_n(max_zero.bytes, sizeof(max_zero) - 8, uint8_t{0xff});
+
     expect_cmp(zero, zero, equal);
     expect_cmp(max, max, equal);
     expect_cmp(zero, max, less);
     expect_cmp(max, zero, greater);
+    expect_cmp(zero_max, max_zero, less);
+    expect_cmp(max_zero, zero_max, greater);
 
     for (size_t i = 0; i < sizeof(evmc::address); ++i)
     {
@@ -260,11 +267,17 @@ TEST(cpp, bytes32_comparison)
     const auto zero = evmc::bytes32{};
     auto max = evmc::bytes32{};
     std::fill_n(max.bytes, sizeof(max), uint8_t{0xff});
+    auto z_max = evmc::bytes32{};
+    std::fill_n(z_max.bytes + 8, sizeof(max) - 8, uint8_t{0xff});
+    auto max_z = evmc::bytes32{};
+    std::fill_n(max_z.bytes, sizeof(max) - 8, uint8_t{0xff});
 
     expect_cmp(zero, zero, equal);
     expect_cmp(max, max, equal);
     expect_cmp(zero, max, less);
     expect_cmp(max, zero, greater);
+    expect_cmp(z_max, max_z, less);
+    expect_cmp(max_z, z_max, greater);
 
     for (size_t i = 0; i < sizeof(evmc::bytes32); ++i)
     {


### PR DESCRIPTION
"load64be(&a.bytes[8]) == load64be(&b.bytes[8])" requires "load64be(&a.bytes[0]) == load64be(&b.bytes[0]" as well, check if load64be(&a.bytes[0]) > load64be(&b.bytes[0] and "load64be(&a.bytes[8]) == load64be(&b.bytes[8])"