### PR TITLE
golang: support go modules

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -5,7 +5,7 @@
 package evmc
 
 /*
-#cgo CFLAGS:  -I${SRCDIR}/.. -Wall -Wextra
+#cgo CFLAGS: -I${SRCDIR}/..  -I${SRCDIR}/../../../include -I${SRCDIR}/../../../lib -Wall -Wextra
 #cgo !windows LDFLAGS: -ldl
 
 #include <evmc/evmc.h>
@@ -14,6 +14,8 @@ package evmc
 
 #include <stdlib.h>
 #include <string.h>
+
+#include "loader/loader.c"
 
 static inline enum evmc_set_option_result set_option(struct evmc_vm* vm, char* name, char* value)
 {

--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -55,16 +55,14 @@ import (
 	"fmt"
 	"sync"
 	"unsafe"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // Static asserts.
 const (
-	_ = uint(common.HashLength - C.sizeof_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
-	_ = uint(C.sizeof_evmc_bytes32 - common.HashLength)
-	_ = uint(common.AddressLength - C.sizeof_evmc_address) // The size of evmc_address equals the size of Address.
-	_ = uint(C.sizeof_evmc_address - common.AddressLength)
+	_ = uint(hashLength - C.sizeof_evmc_bytes32) // The size of evmc_bytes32 equals the size of Hash.
+	_ = uint(C.sizeof_evmc_bytes32 - hashLength)
+	_ = uint(addressLength - C.sizeof_evmc_address) // The size of evmc_address equals the size of Address.
+	_ = uint(C.sizeof_evmc_address - addressLength)
 )
 
 type Error int32
@@ -222,8 +220,8 @@ func (vm *VM) SetOption(name string, value string) (err error) {
 
 func (vm *VM) Execute(ctx HostContext, rev Revision,
 	kind CallKind, static bool, depth int, gas int64,
-	destination common.Address, sender common.Address, input []byte, value common.Hash,
-	code []byte, create2Salt common.Hash) (output []byte, gasLeft int64, err error) {
+	destination Address, sender Address, input []byte, value Hash,
+	code []byte, create2Salt Hash) (output []byte, gasLeft int64, err error) {
 
 	flags := C.uint32_t(0)
 	if static {
@@ -283,7 +281,7 @@ func getHostContext(idx uintptr) HostContext {
 	return ctx
 }
 
-func evmcBytes32(in common.Hash) C.evmc_bytes32 {
+func evmcBytes32(in Hash) C.evmc_bytes32 {
 	out := C.evmc_bytes32{}
 	for i := 0; i < len(in); i++ {
 		out.bytes[i] = C.uint8_t(in[i])
@@ -291,7 +289,7 @@ func evmcBytes32(in common.Hash) C.evmc_bytes32 {
 	return out
 }
 
-func evmcAddress(address common.Address) C.evmc_address {
+func evmcAddress(address Address) C.evmc_address {
 	r := C.evmc_address{}
 	for i := 0; i < len(address); i++ {
 		r.bytes[i] = C.uint8_t(address[i])

--- a/bindings/go/evmc/evmc.h
+++ b/bindings/go/evmc/evmc.h
@@ -1,1 +1,0 @@
-../../../include/evmc/evmc.h

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -9,8 +9,6 @@ package evmc
 import (
 	"bytes"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 var modulePath = "./example_vm.so"
@@ -47,8 +45,8 @@ func TestExecute(t *testing.T) {
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
-	addr := common.Address{}
-	h := common.Hash{}
+	addr := Address{}
+	h := Hash{}
 	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil, h)
 
 	if bytes.Compare(output, []byte("Welcome to Byzantium!")) != 0 {

--- a/bindings/go/evmc/helpers.h
+++ b/bindings/go/evmc/helpers.h
@@ -1,1 +1,0 @@
-../../../include/evmc/helpers.h

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -1,10 +1,11 @@
+// EVMC: Ethereum Client-VM Connector API.
 // Copyright 2018-2019 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
 package evmc
 
 /*
-#cgo CFLAGS:  -I${SRCDIR}/.. -Wall -Wextra -Wno-unused-parameter
+#cgo CFLAGS: -I${SRCDIR}/..  -I${SRCDIR}/../../../include -Wall -Wextra -Wno-unused-parameter
 
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -1,4 +1,3 @@
-// EVMC: Ethereum Client-VM Connector API.
 // Copyright 2018-2019 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
@@ -15,8 +14,6 @@ import "C"
 import (
 	"math/big"
 	"unsafe"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type CallKind int
@@ -39,16 +36,16 @@ const (
 	StorageDeleted       StorageStatus = C.EVMC_STORAGE_DELETED
 )
 
-func goAddress(in C.evmc_address) common.Address {
-	out := common.Address{}
+func goAddress(in C.evmc_address) Address {
+	out := Address{}
 	for i := 0; i < len(out); i++ {
 		out[i] = byte(in.bytes[i])
 	}
 	return out
 }
 
-func goHash(in C.evmc_bytes32) common.Hash {
-	out := common.Hash{}
+func goHash(in C.evmc_bytes32) Hash {
+	out := Hash{}
 	for i := 0; i < len(out); i++ {
 		out[i] = byte(in.bytes[i])
 	}
@@ -64,31 +61,31 @@ func goByteSlice(data *C.uint8_t, size C.size_t) []byte {
 
 // TxContext contains information about current transaction and block.
 type TxContext struct {
-	GasPrice   common.Hash
-	Origin     common.Address
-	Coinbase   common.Address
+	GasPrice   Hash
+	Origin     Address
+	Coinbase   Address
 	Number     int64
 	Timestamp  int64
 	GasLimit   int64
-	Difficulty common.Hash
-	ChainID    common.Hash
+	Difficulty Hash
+	ChainID    Hash
 }
 
 type HostContext interface {
-	AccountExists(addr common.Address) bool
-	GetStorage(addr common.Address, key common.Hash) common.Hash
-	SetStorage(addr common.Address, key common.Hash, value common.Hash) StorageStatus
-	GetBalance(addr common.Address) common.Hash
-	GetCodeSize(addr common.Address) int
-	GetCodeHash(addr common.Address) common.Hash
-	GetCode(addr common.Address) []byte
-	Selfdestruct(addr common.Address, beneficiary common.Address)
+	AccountExists(addr Address) bool
+	GetStorage(addr Address, key Hash) Hash
+	SetStorage(addr Address, key Hash, value Hash) StorageStatus
+	GetBalance(addr Address) Hash
+	GetCodeSize(addr Address) int
+	GetCodeHash(addr Address) Hash
+	GetCode(addr Address) []byte
+	Selfdestruct(addr Address, beneficiary Address)
 	GetTxContext() TxContext
-	GetBlockHash(number int64) common.Hash
-	EmitLog(addr common.Address, topics []common.Hash, data []byte)
+	GetBlockHash(number int64) Hash
+	EmitLog(addr Address, topics []Hash, data []byte)
 	Call(kind CallKind,
-		destination common.Address, sender common.Address, value *big.Int, input []byte, gas int64, depth int,
-		static bool, salt *big.Int) (output []byte, gasLeft int64, createAddr common.Address, err error)
+		destination Address, sender Address, value *big.Int, input []byte, gas int64, depth int,
+		static bool, salt *big.Int) (output []byte, gasLeft int64, createAddr Address, err error)
 }
 
 //export accountExists
@@ -186,7 +183,7 @@ func emitLog(pCtx unsafe.Pointer, pAddr *C.evmc_address, pData unsafe.Pointer, d
 	tData := C.GoBytes(pTopics, C.int(topicsCount*32))
 
 	nTopics := int(topicsCount)
-	topics := make([]common.Hash, nTopics)
+	topics := make([]Hash, nTopics)
 	for i := 0; i < nTopics; i++ {
 		copy(topics[i][:], tData[i*32:(i+1)*32])
 	}

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -8,41 +8,39 @@ import (
 	"bytes"
 	"math/big"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type testHostContext struct{}
 
-func (host *testHostContext) AccountExists(addr common.Address) bool {
+func (host *testHostContext) AccountExists(addr Address) bool {
 	return false
 }
 
-func (host *testHostContext) GetStorage(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash{}
+func (host *testHostContext) GetStorage(addr Address, key Hash) Hash {
+	return Hash{}
 }
 
-func (host *testHostContext) SetStorage(addr common.Address, key common.Hash, value common.Hash) (status StorageStatus) {
+func (host *testHostContext) SetStorage(addr Address, key Hash, value Hash) (status StorageStatus) {
 	return StorageUnchanged
 }
 
-func (host *testHostContext) GetBalance(addr common.Address) common.Hash {
-	return common.Hash{}
+func (host *testHostContext) GetBalance(addr Address) Hash {
+	return Hash{}
 }
 
-func (host *testHostContext) GetCodeSize(addr common.Address) int {
+func (host *testHostContext) GetCodeSize(addr Address) int {
 	return 0
 }
 
-func (host *testHostContext) GetCodeHash(addr common.Address) common.Hash {
-	return common.Hash{}
+func (host *testHostContext) GetCodeHash(addr Address) Hash {
+	return Hash{}
 }
 
-func (host *testHostContext) GetCode(addr common.Address) []byte {
+func (host *testHostContext) GetCode(addr Address) []byte {
 	return nil
 }
 
-func (host *testHostContext) Selfdestruct(addr common.Address, beneficiary common.Address) {
+func (host *testHostContext) Selfdestruct(addr Address, beneficiary Address) {
 }
 
 func (host *testHostContext) GetTxContext() TxContext {
@@ -51,18 +49,18 @@ func (host *testHostContext) GetTxContext() TxContext {
 	return txContext
 }
 
-func (host *testHostContext) GetBlockHash(number int64) common.Hash {
-	return common.Hash{}
+func (host *testHostContext) GetBlockHash(number int64) Hash {
+	return Hash{}
 }
 
-func (host *testHostContext) EmitLog(addr common.Address, topics []common.Hash, data []byte) {
+func (host *testHostContext) EmitLog(addr Address, topics []Hash, data []byte) {
 }
 
 func (host *testHostContext) Call(kind CallKind,
-	destination common.Address, sender common.Address, value *big.Int, input []byte, gas int64, depth int,
-	static bool, salt *big.Int) (output []byte, gasLeft int64, createAddr common.Address, err error) {
+	destination Address, sender Address, value *big.Int, input []byte, gas int64, depth int,
+	static bool, salt *big.Int) (output []byte, gasLeft int64, createAddr Address, err error) {
 	output = []byte("output from testHostContext.Call()")
-	return output, gas, common.Address{}, nil
+	return output, gas, Address{}, nil
 }
 
 func TestGetTxContext(t *testing.T) {
@@ -72,8 +70,8 @@ func TestGetTxContext(t *testing.T) {
 	host := &testHostContext{}
 	code := []byte("\x43\x60\x00\x52\x59\x60\x00\xf3")
 
-	addr := common.Address{}
-	h := common.Hash{}
+	addr := Address{}
+	h := Hash{}
 	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
 
 	if len(output) != 20 {
@@ -97,8 +95,8 @@ func TestCall(t *testing.T) {
 	host := &testHostContext{}
 	code := []byte("\x60\x00\x80\x80\x80\x80\x80\x80\xf1")
 
-	addr := common.Address{}
-	h := common.Hash{}
+	addr := Address{}
+	h := Hash{}
 	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
 
 	if bytes.Compare(output, []byte("output from testHostContext.Call()")) != 0 {

--- a/bindings/go/evmc/loader.c
+++ b/bindings/go/evmc/loader.c
@@ -1,1 +1,0 @@
-../../../lib/loader/loader.c

--- a/bindings/go/evmc/loader.h
+++ b/bindings/go/evmc/loader.h
@@ -1,1 +1,0 @@
-../../../include/evmc/loader.h

--- a/bindings/go/evmc/types.go
+++ b/bindings/go/evmc/types.go
@@ -1,0 +1,20 @@
+package evmc
+
+import "math/big"
+
+// Lengths of hashes and addresses in bytes.
+const (
+	// hashLength is the expected length of the hash (in bytes)
+	hashLength = 32
+	// addressLength is the expected length of the address (in bytes)
+	addressLength = 20
+)
+
+// Hash represents the 32 byte Keccak256 hash of arbitrary data.
+type Hash [hashLength]byte
+
+// Big converts a hash to a big integer.
+func (h Hash) Big() *big.Int { return new(big.Int).SetBytes(h[:]) }
+
+// Address represents the 20 byte address of an Ethereum account.
+type Address [addressLength]byte

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ethereum/evmc/v7
+
+go 1.14


### PR DESCRIPTION
Should be merged after https://github.com/ethereum/evmc/pull/499 (includes it)
  
(1) remove symlinks that confuse go modules
(2) `go mod init`