### PR TITLE
java: Build update

### DIFF
--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -2,7 +2,7 @@ OS:=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ifeq ($(OS), linux)
 	EXT:=so
 	OS_LFLAGS:=
-	JAVA_HOME:=/usr/local/openjdk-11
+	JAVA_HOME:=$(shell java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | sed 's/\s*java.home = //' | sed 's/\/jre//')
 else ifeq ($(OS), darwin)
 	EXT:=so
 	OS_LFLAGS:=-mmacosx-version-min=$(shell defaults read loginwindow SystemVersionStampAsString) -framework CoreFoundation -framework Security
@@ -17,7 +17,7 @@ LFLAGS = -shared
 OUT_DIR = ./c/build
 
 gradlew:
-	gradle setup
+	gradle --no-daemon setup
 
 build: gradlew
 	mkdir -p $(OUT_DIR)

--- a/bindings/java/build.gradle
+++ b/bindings/java/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.diffplug.gradle.spotless' version '3.16.0'
+    id 'com.diffplug.gradle.spotless' version '3.29.0'
 }
 apply from: "${rootDir}/wrapper.gradle"
 allprojects {

--- a/bindings/java/wrapper.gradle
+++ b/bindings/java/wrapper.gradle
@@ -1,4 +1,4 @@
 task setup(type: Wrapper) {
     description = "Download the gradle wrapper and requisite files. Overwrites existing wrapper files."
-    gradleVersion = "5.0"
+    gradleVersion = "6.3"
 }

--- a/circle.yml
+++ b/circle.yml
@@ -237,7 +237,7 @@ jobs:
 
   bindings-java:
     docker:
-      - image: circleci/openjdk:11-buster
+      - image: circleci/openjdk:13-buster
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This is Java build system maintenance work and to fix my local build based on OpenJDK 13. I believe Gradle 6 is needed for OpenJDK 13.

There are some additional questions:
- The `build/evmc.jar` (produced by gradle?) is empty.
- I can build `evmc.so` with JNI using CMake. That would be preferable than using the custom Makefile.
- I can also build `evmc.jar` with CMake. So we may only need gradle to do testing (get JUnit5) and "spotless"?