### PR TITLE
java: prefix C exports with evmc_java_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning].
   [#455](https://github.com/ethereum/evmc/pull/455)
   [#490](https://github.com/ethereum/evmc/pull/490)
   [#503](https://github.com/ethereum/evmc/pull/503)
+  [#512](https://github.com/ethereum/evmc/pull/512)
 - New **evmc command-line tool** has been added. At the moment it supports
   command _run_ for executing bytecode in any EVMC-compatible VM implementation.
   Try `evmc run --help` for more information.

--- a/bindings/java/c/evmc-vm.c
+++ b/bindings/java/c/evmc-vm.c
@@ -24,7 +24,7 @@ JNIEXPORT jobject JNICALL Java_org_ethereum_evmc_EvmcVm_init(JNIEnv* jenv,
 {
     (void)jcls;
     struct evmc_vm* evm = NULL;
-    jint rs = set_jvm(jenv);
+    jint rs = evmc_java_set_jvm(jenv);
     (void)rs;
     assert(rs == JNI_OK);
     // load the EVM
@@ -101,7 +101,7 @@ JNIEXPORT void JNICALL Java_org_ethereum_evmc_EvmcVm_execute(JNIEnv* jenv,
     struct evmc_host_context context = {jcontext_index};
     struct evmc_vm* evm = (struct evmc_vm*)(*jenv)->GetDirectBufferAddress(jenv, jevm);
     assert(evm != NULL);
-    const struct evmc_host_interface* host = get_host_interface();
+    const struct evmc_host_interface* host = evmc_java_get_host_interface();
     struct evmc_result* result =
         (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
     assert(result != NULL);

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -10,7 +10,7 @@
 
 static JavaVM* jvm;
 
-int set_jvm(JNIEnv* jenv)
+int evmc_java_set_jvm(JNIEnv* jenv)
 {
     return (*jenv)->GetJavaVM(jenv, &jvm);
 }
@@ -532,7 +532,7 @@ static void emit_log_fn(struct evmc_host_context* context,
     return;
 }
 
-const struct evmc_host_interface* get_host_interface()
+const struct evmc_host_interface* evmc_java_get_host_interface()
 {
     static const struct evmc_host_interface host = {
         account_exists_fn, get_storage_fn,    set_storage_fn,    get_balance_fn,

--- a/bindings/java/c/host.h
+++ b/bindings/java/c/host.h
@@ -12,8 +12,8 @@ struct evmc_host_context
     int index;
 };
 
-int set_jvm(JNIEnv*);
-const struct evmc_host_interface* get_host_interface();
+int evmc_java_set_jvm(JNIEnv*);
+const struct evmc_host_interface* evmc_java_get_host_interface();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Similarly to how we prefix with evmc_go_ in the go bindings.

See https://github.com/ethereum/evmc/blob/master/bindings/go/evmc/host.c#L16.

Probably it doesn't matter too much as long as the `bindings/java/c` directory is a compiled to a single shared library, which I think it is.