### PR TITLE
cpp: Require C++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Please visit the [documentation].
 
 | Language                      | Supported Versions    | Supported Compilers            | Feature Support
 | ----------------------------- | --------------------- | ------------------------------ | -------------------
-| **C**                         | C99, C11              | GCC 6+, clang 3.8+, MSVC 2015+ | Host- and VM-side
-| **C++**                       | C++11, C++14, C++17   | GCC 6+, clang 3.8+, MSVC 2015+ | Host- and VM-side
+| **C**                         | C99, C11              | GCC 6+, clang 3.8+, MSVC 2017+ | Host- and VM-side
+| **C++**                       | C++14, C++17          | GCC 6+, clang 3.8+, MSVC 2017+ | Host- and VM-side
 | **Go** _(bindings)_           | 1.11 - 1.14 (modules) |                                | Host-side only
 | **Rust** _(bindings)_[¹](#n1) | 2018 edition          | 1.37.0 and newer               | VM-side only
 | **Java** _(bindings)_         | 11                    |                                | Host-side only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,18 +12,16 @@ environment:
   matrix:
     - VS: 2019
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - VS: 2017
     - VS: 2017-32bit
-    - VS: 2015
     - GO: true
 cache:
   - C:\.hunter\_Base\Cache -> cmake\Hunter\init.cmake
 
 before_build:
-  # Add ninja to PATH. This is done for VS2017 by vsdevcmd, but not for VS2015.
-  - set PATH=%PATH%;%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja
   - if "%VS%" == "2019" (call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools\vsdevcmd" -arch=amd64)
+  - if "%VS%" == "2017" (call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=amd64)
   - if "%VS%" == "2017-32bit" (call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=x86)
-  - if "%VS%" == "2015" (call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall" x64)
   - if defined VS cmake -S . -B build -G Ninja -Wno-dev -DTOOLCHAIN=cxx17-pic -DEVMC_TESTING=ON
 
 build_script:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018-2019 The EVMC Authors.
+# Copyright 2018-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 add_library(evmc INTERFACE)
@@ -8,7 +8,7 @@ target_include_directories(evmc INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INS
 
 add_library(evmc_cpp INTERFACE)
 add_library(evmc::evmc_cpp ALIAS evmc_cpp)
-target_compile_features(evmc_cpp INTERFACE cxx_std_11)
+target_compile_features(evmc_cpp INTERFACE cxx_std_14)
 target_include_directories(evmc_cpp INTERFACE $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)
 target_link_libraries(evmc_cpp INTERFACE evmc::evmc)
 

--- a/test/compilation/CMakeLists.txt
+++ b/test/compilation/CMakeLists.txt
@@ -1,11 +1,11 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018-2019 The EVMC Authors.
+# Copyright 2018-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 # This CMake script creates multiple additional targets to test the compilation of public headers
 # with different C and C++ standards.
 
-set(standards c_std_99;c_std_11;cxx_std_11;cxx_std_14)
+set(standards c_std_99;c_std_11;cxx_std_14)
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.1)
     list(APPEND standards cxx_std_17)
 endif()


### PR DESCRIPTION
Bump C++ standard required from C++11 to C++14. This also drops support
for Visual Studio 2015.