### PR TITLE
rust: only allow whitelisted types in the generated bindings

### DIFF
--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -23,6 +23,9 @@ fn gen_bindings() {
         // force deriving the Hash trait on basic types (address, bytes32)
         .derive_hash(true)
         .opaque_type("evmc_host_context")
+        .whitelist_type("evmc_.*")
+        .whitelist_function("evmc_.*")
+        .whitelist_var("EVMC_ABI_VERSION")
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This removes any stray types added by the local system, such as "stdint" on macOS.