### PR TITLE
rust: turn evmc_host_context into a void type

### DIFF
--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -19,7 +19,7 @@ fn gen_bindings() {
         .derive_hash(true)
         // force deriving the PratialEq trait on basic types (address, bytes32)
         .derive_partialeq(true)
-        .opaque_type("evmc_host_context")
+        .blocklist_type("evmc_host_context")
         .allowlist_type("evmc_.*")
         .allowlist_function("evmc_.*")
         .allowlist_var("EVMC_ABI_VERSION")

--- a/bindings/rust/evmc-sys/src/lib.rs
+++ b/bindings/rust/evmc-sys/src/lib.rs
@@ -8,6 +8,11 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+// Defining evmc_host_context here, because bindgen cannot create a useful declaration yet.
+
+/// This is a void type given host context is an opaque pointer. Functions allow it to be a null ptr.
+pub type evmc_host_context = ::std::os::raw::c_void;
+
 // TODO: add `.derive_default(true)` to bindgen instead?
 
 impl Default for evmc_address {


### PR DESCRIPTION
This may be needed for #476.