### PR TITLE
Add EVMC_INSUFFICIENT_BALANCE error to evmc_status_code

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -118,6 +118,8 @@ func (err Error) Error() string {
 		return "evmc: the WebAssembly unreachable instruction has been hit during execution"
 	case C.EVMC_WASM_TRAP:
 		return "evmc: a WebAssembly trap has been hit during execution"
+	case C.EVMC_INSUFFICIENT_BALANCE:
+		return "evmc: insufficient balance"
 	case C.EVMC_REJECTED:
 		return "evmc: rejected"
 	}

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -295,6 +295,9 @@ enum evmc_status_code
      */
     EVMC_WASM_TRAP = 16,
 
+    /** The caller does not have enough funds for value transfer. */
+    EVMC_INSUFFICIENT_BALANCE = 17,
+
     /** EVM implementation generic internal error. */
     EVMC_INTERNAL_ERROR = -1,
 

--- a/tools/evmc/utils.cpp
+++ b/tools/evmc/utils.cpp
@@ -102,6 +102,9 @@ std::ostream& operator<<(std::ostream& os, evmc_status_code status_code)
     case EVMC_WASM_TRAP:
         s = "wasm trap";
         break;
+    case EVMC_INSUFFICIENT_BALANCE:
+        s = "insufficient balance";
+        break;
     case EVMC_INTERNAL_ERROR:
         s = "internal error";
         break;


### PR DESCRIPTION
EVMC_BALANCE_TOO_LOW describes the situation when the caller doesn't have enough funds for value transfer. Useful on the host side for CREATE, CALL and ilk.