### PR TITLE
ci: Skip gomod integration test in "PRs from forks"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -268,6 +268,8 @@ jobs:
           name: "Go module integration test"
           working_directory: test/gomod
           command: |
+            test -z "$CIRCLE_PR_USERNAME" || (echo "Skip for PRs from forks" && exit 0)
+
             V=$CIRCLE_TAG
             if [ -z $V ]; then
               V=$CIRCLE_SHA1


### PR DESCRIPTION
This disables running gomod integration test in PRs from forked repos. It was expected this test not to work as it would require to pull the commit from the fork as the version of `github.com/ethereum/evmc` module.

The same commit from withing `ethereum/evmc` repo: https://circleci.com/gh/ethereum/evmc/24915.