### PR TITLE
Bundle shared libs in jar, so it becomes easier to install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 /.idea
 Cargo.lock
 /target
-bindings/java/java/src/main/resources
-bindings/java/java/src/test/resources

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.idea
 Cargo.lock
 /target
+bindings/java/java/src/main/resources
+bindings/java/java/src/test/resources

--- a/bindings/java/.gitignore
+++ b/bindings/java/.gitignore
@@ -21,3 +21,5 @@ gradlew
 gradlew.bat
 c/evmc-vm.h
 *.class
+java/src/main/resources
+java/src/test/resources

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -22,6 +22,10 @@ $(OUT_DIR)/lib/libevmc-java.so:
 	mkdir -p $(BUILD_DIR)
 	(cd $(BUILD_DIR) && cmake $(SOURCE_DIR) -DCMAKE_INSTALL_PREFIX=$(OUT_DIR) -DEVMC_JAVA=ON -DJAVA_HOME=$(JAVA_HOME) -DEVMC_EXAMPLES=ON)
 	cmake --build $(OUT_DIR)/_cmake_build --target install
+	mkdir -p java/src/main/resources
+	mkdir -p java/src/test/resources
+	cp $(OUT_DIR)/lib/libevmc-java.* $(CURDIR)/java/src/main/resources/libevmc.so
+	cp $(OUT_DIR)/lib/libexample-vm.* $(CURDIR)/java/src/test/resources/libexample-vm.so
 
 clean:
 	rm -rf $(OUT_DIR)

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -41,28 +41,26 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        // call java method
-        jint jresult =
-            (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
-        result = !!jresult;
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
+    result = !!jresult;
 
     return result;
 }
@@ -77,35 +75,33 @@ static evmc_bytes32 get_storage_fn(struct evmc_host_context* context,
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jkey;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jkey;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
-                                                          jaddress, jkey);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress, jkey);
 
-        assert(jresult != NULL);
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    assert(jresult != NULL);
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
     return result;
 }
@@ -121,32 +117,31 @@ static enum evmc_storage_status set_storage_fn(struct evmc_host_context* context
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jkey;
-        jbyteArray jval;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jkey;
+    jbyteArray jval;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
-        jval = CopyDataToJava(jenv, value, sizeof(struct evmc_bytes32));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
+    jval = CopyDataToJava(jenv, value, sizeof(struct evmc_bytes32));
 
-        // call java method
-        jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index,
-                                                    jaddress, jkey, jval);
-        result = (enum evmc_storage_status)jresult;
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress,
+                                                jkey, jval);
+    result = (enum evmc_storage_status)jresult;
 
     return result;
 }
@@ -159,35 +154,33 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
+    assert(jresult != NULL);
 
-        evmc_uint256be* result_ptr =
-            (evmc_uint256be*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    evmc_uint256be* result_ptr = (evmc_uint256be*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
 
     return result;
 }
@@ -199,28 +192,26 @@ static size_t get_code_size_fn(struct evmc_host_context* context, const evmc_add
     char java_method_signature[] = "(I[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        // call java method
-        jint jresult =
-            (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
-        result = (size_t)jresult;
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
+    result = (size_t)jresult;
 
     return result;
 }
@@ -233,35 +224,33 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
+    assert(jresult != NULL);
 
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
     return result;
 }
 
@@ -277,38 +266,37 @@ static size_t copy_code_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[BI)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jint jcode_offset = (jint)code_offset;
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jint jcode_offset = (jint)code_offset;
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
-                                                          jaddress, jcode_offset);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
+                                                      jaddress, jcode_offset);
+    assert(jresult != NULL);
 
-        // copy jresult back to buffer_data
-        buffer_data = (uint8_t*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        (void)buffer_data;
-        assert(buffer_data != NULL);
+    // copy jresult back to buffer_data
+    buffer_data = (uint8_t*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    (void)buffer_data;
+    assert(buffer_data != NULL);
 
-        result = get_code_size_fn(context, address) - code_offset;
+    result = get_code_size_fn(context, address) - code_offset;
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
 
     return result;
 }
@@ -322,30 +310,27 @@ static void selfdestruct_fn(struct evmc_host_context* context,
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jbeneficiary;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jbeneficiary;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jbeneficiary = CopyDataToJava(jenv, beneficiary, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jbeneficiary = CopyDataToJava(jenv, beneficiary, sizeof(struct evmc_address));
 
-        // call java method
-        (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress,
-                                     jbeneficiary);
-
+    // call java method
+    (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jbeneficiary);
 }
 
 static struct evmc_result call_fn(struct evmc_host_context* context, const struct evmc_message* msg)
@@ -356,35 +341,34 @@ static struct evmc_result call_fn(struct evmc_host_context* context, const struc
     JNIEnv* jenv = attach();
     assert(context != NULL);
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jobject jmsg;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jobject jmsg;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // set java method params
+    jcontext_index = context->index;
 
-        jmsg = (*jenv)->NewDirectByteBuffer(jenv, (void*)msg, sizeof(struct evmc_message));
-        assert(jmsg != NULL);
+    jmsg = (*jenv)->NewDirectByteBuffer(jenv, (void*)msg, sizeof(struct evmc_message));
+    assert(jmsg != NULL);
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jmsg);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jmsg);
+    assert(jresult != NULL);
 
-        struct evmc_result* result_ptr =
-            (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    struct evmc_result* result_ptr =
+        (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
     return result;
 }
@@ -396,30 +380,29 @@ static struct evmc_tx_context get_tx_context_fn(struct evmc_host_context* contex
     const char java_method_signature[] = "(I)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // set java method params
+    jcontext_index = context->index;
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index);
+    assert(jresult != NULL);
 
-        struct evmc_tx_context* result_ptr =
-            (struct evmc_tx_context*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    struct evmc_tx_context* result_ptr =
+        (struct evmc_tx_context*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
     return result;
 }
@@ -433,34 +416,32 @@ static evmc_bytes32 get_block_hash_fn(struct evmc_host_context* context, int64_t
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jlong jnumber;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jlong jnumber;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // set java method params
+    jcontext_index = context->index;
 
-        jnumber = (jlong)number;
+    jnumber = (jlong)number;
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jnumber);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jnumber);
+    assert(jresult != NULL);
 
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
     return result;
 }
@@ -477,40 +458,39 @@ static void emit_log_fn(struct evmc_host_context* context,
     assert(context != NULL);
     JNIEnv* jenv = attach();
 
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jdata;
-        jobjectArray jtopics;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jdata;
+    jobjectArray jtopics;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jdata = CopyDataToJava(jenv, data, data_size);
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jdata = CopyDataToJava(jenv, data, data_size);
 
-        jclass byte_type = (*jenv)->FindClass(jenv, "[B");
-        jtopics = (*jenv)->NewObjectArray(jenv, (jsize)topics_count, byte_type, NULL);
-        assert(jtopics != NULL);
-        for (size_t i = 0; i < topics_count; i++)
-        {
-            jbyteArray jtopic = CopyDataToJava(jenv, topics[i].bytes, sizeof(struct evmc_bytes32));
-            (*jenv)->SetObjectArrayElement(jenv, jtopics, (jsize)i, jtopic);
-            (*jenv)->DeleteLocalRef(jenv, jtopic);
-        }
+    jclass byte_type = (*jenv)->FindClass(jenv, "[B");
+    jtopics = (*jenv)->NewObjectArray(jenv, (jsize)topics_count, byte_type, NULL);
+    assert(jtopics != NULL);
+    for (size_t i = 0; i < topics_count; i++)
+    {
+        jbyteArray jtopic = CopyDataToJava(jenv, topics[i].bytes, sizeof(struct evmc_bytes32));
+        (*jenv)->SetObjectArrayElement(jenv, jtopics, (jsize)i, jtopic);
+        (*jenv)->DeleteLocalRef(jenv, jtopic);
+    }
 
-        // call java method
-        (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jdata,
-                                     data_size, jtopics, topics_count);
+    // call java method
+    (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jdata,
+                                 data_size, jtopics, topics_count);
 }
 
 const struct evmc_host_interface* evmc_java_get_host_interface()

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -40,8 +40,7 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
     const char java_method_signature[] = "(I[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -64,7 +63,7 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
         jint jresult =
             (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
         result = !!jresult;
-    }
+
     return result;
 }
 
@@ -77,8 +76,7 @@ static evmc_bytes32 get_storage_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -108,7 +106,7 @@ static evmc_bytes32 get_storage_fn(struct evmc_host_context* context,
             (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
         assert(result_ptr != NULL);
         result = *result_ptr;
-    }
+
     return result;
 }
 
@@ -122,8 +120,7 @@ static enum evmc_storage_status set_storage_fn(struct evmc_host_context* context
     const char java_method_signature[] = "(I[B[B[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -150,7 +147,7 @@ static enum evmc_storage_status set_storage_fn(struct evmc_host_context* context
         jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index,
                                                     jaddress, jkey, jval);
         result = (enum evmc_storage_status)jresult;
-    }
+
     return result;
 }
 
@@ -161,8 +158,7 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
     char java_method_signature[] = "(I[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -192,7 +188,7 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
         result = *result_ptr;
 
         (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
+
     return result;
 }
 
@@ -203,8 +199,6 @@ static size_t get_code_size_fn(struct evmc_host_context* context, const evmc_add
     char java_method_signature[] = "(I[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -227,7 +221,7 @@ static size_t get_code_size_fn(struct evmc_host_context* context, const evmc_add
         jint jresult =
             (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
         result = (size_t)jresult;
-    }
+
     return result;
 }
 
@@ -238,8 +232,7 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
     char java_method_signature[] = "(I[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -269,7 +262,6 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
         result = *result_ptr;
 
         (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
     return result;
 }
 
@@ -285,8 +277,6 @@ static size_t copy_code_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[BI)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -319,7 +309,7 @@ static size_t copy_code_fn(struct evmc_host_context* context,
         result = get_code_size_fn(context, address) - code_offset;
 
         (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
+
     return result;
 }
 
@@ -331,8 +321,7 @@ static void selfdestruct_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[B)V";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -356,8 +345,7 @@ static void selfdestruct_fn(struct evmc_host_context* context,
         // call java method
         (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress,
                                      jbeneficiary);
-    }
-    return;
+
 }
 
 static struct evmc_result call_fn(struct evmc_host_context* context, const struct evmc_message* msg)
@@ -367,8 +355,7 @@ static struct evmc_result call_fn(struct evmc_host_context* context, const struc
     const char java_method_signature[] = "(ILjava/nio/ByteBuffer;)Ljava/nio/ByteBuffer;";
     JNIEnv* jenv = attach();
     assert(context != NULL);
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -398,7 +385,7 @@ static struct evmc_result call_fn(struct evmc_host_context* context, const struc
             (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
         assert(result_ptr != NULL);
         result = *result_ptr;
-    }
+
     return result;
 }
 
@@ -409,8 +396,6 @@ static struct evmc_tx_context get_tx_context_fn(struct evmc_host_context* contex
     const char java_method_signature[] = "(I)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -435,7 +420,7 @@ static struct evmc_tx_context get_tx_context_fn(struct evmc_host_context* contex
             (struct evmc_tx_context*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
         assert(result_ptr != NULL);
         result = *result_ptr;
-    }
+
     return result;
 }
 
@@ -447,8 +432,7 @@ static evmc_bytes32 get_block_hash_fn(struct evmc_host_context* context, int64_t
     char java_method_signature[] = "(IJ)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -477,7 +461,7 @@ static evmc_bytes32 get_block_hash_fn(struct evmc_host_context* context, int64_t
             (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
         assert(result_ptr != NULL);
         result = *result_ptr;
-    }
+
     return result;
 }
 
@@ -492,8 +476,7 @@ static void emit_log_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[BI[[BI)V";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
+
         jclass host_class;
         jmethodID method;
         jint jcontext_index;
@@ -528,8 +511,6 @@ static void emit_log_fn(struct evmc_host_context* context,
         // call java method
         (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jdata,
                                      data_size, jtopics, topics_count);
-    }
-    return;
 }
 
 const struct evmc_host_interface* evmc_java_get_host_interface()

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class EvmcTest {
-  private static final String exampleVmPath =
-      System.getProperty("user.dir") + "/../c/build/lib/libexample-vm.so";
+  private static final String exampleVmPath = EvmcTest.class.getResource("/libexample-vm.so").getFile();
 
   @Test
   void testInitCloseDestroy() throws Exception {


### PR DESCRIPTION
This PR allows to search for libevmc in paths, and will install locally a libevmc as a temporary file if needed if the .so file is not found in the path.
This PR also resolves the test example-vm.so file to the Java tests so they don't depend on the user dir.