### PR TITLE
java: Use allocateDirect instead of wrap in copy_code

### DIFF
--- a/bindings/java/java/src/main/java/org/ethereum/evmc/Host.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/Host.java
@@ -79,10 +79,10 @@ final class Host {
 
     if (code != null && code_offset > 0 && code_offset < code.length) {
       int length = code.length - code_offset;
-      return ByteBuffer.wrap(code, 0, length);
+      return ByteBuffer.allocateDirect(length).put(code, code_offset, length);
     }
 
-    return ByteBuffer.wrap(new byte[0]);
+    return ByteBuffer.allocateDirect(0);
   }
 
   /** Selfdestruct callback function. */


### PR DESCRIPTION
Peeling off a change from #532 to single it out. This fixes a bug in how Java interfaces with JNI. JNI requires a direct buffer allocation instead of a heap bytebuffer.