### PR TITLE
Add a method to provide a bytebuffer address

### DIFF
--- a/bindings/java/c/evmc-vm.c
+++ b/bindings/java/c/evmc-vm.c
@@ -138,6 +138,15 @@ JNIEXPORT jint JNICALL Java_org_ethereum_evmc_EvmcVm_set_1option(JNIEnv* jenv,
     return (jint)option_result;
 }
 
+JNIEXPORT jlong JNICALL Java_org_ethereum_evmc_EvmcVm_address(JNIEnv* jenv,
+                                                              jclass jcls,
+                                                              jobject buf)
+{
+    (void)jcls;
+    void* p = (*jenv)->GetDirectBufferAddress(jenv, buf);
+    return (jlong)p;
+}
+
 JNIEXPORT jint JNICALL Java_org_ethereum_evmc_EvmcVm_get_1result_1size(JNIEnv* jenv, jclass jcls)
 {
     (void)jenv;

--- a/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
@@ -156,6 +156,13 @@ public final class EvmcVm implements AutoCloseable {
   native int get_result_size();
 
   /**
+   * Utility method to get a bytebuffer address
+   * @param buffer the byte buffer to consider
+   * @return the byte buffer address
+   */
+  native long address(ByteBuffer buffer);
+
+  /**
    * This method cleans up resources
    *
    * @throws Exception


### PR DESCRIPTION
Adds a native JNI method to provide the address of a ByteBuffer. This is used by the code to call out to EVMC which asks for the memory address of the ByteBuffer rather than its contents.