### PR TITLE
java: Remove all the unnecessary JNIEnv checks

### DIFF
--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -21,6 +21,7 @@ static JNIEnv* attach()
     jint rs = (*jvm)->AttachCurrentThread(jvm, (void**)&jenv, NULL);
     (void)rs;
     assert(rs == JNI_OK);
+    assert(jenv != NULL);
     return jenv;
 }
 
@@ -40,31 +41,28 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
     const char java_method_signature[] = "(I[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jint jresult =
-            (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
-        result = !!jresult;
-    }
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
+    result = !!jresult;
+
     return result;
 }
 
@@ -77,38 +75,35 @@ static evmc_bytes32 get_storage_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jkey;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jkey;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
-                                                          jaddress, jkey);
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
 
-        assert(jresult != NULL);
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
-    }
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress, jkey);
+
+    assert(jresult != NULL);
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
+
     return result;
 }
 
@@ -122,35 +117,33 @@ static enum evmc_storage_status set_storage_fn(struct evmc_host_context* context
     const char java_method_signature[] = "(I[B[B[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jkey;
-        jbyteArray jval;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jkey;
+    jbyteArray jval;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
-        jval = CopyDataToJava(jenv, value, sizeof(struct evmc_bytes32));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index,
-                                                    jaddress, jkey, jval);
-        result = (enum evmc_storage_status)jresult;
-    }
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jkey = CopyDataToJava(jenv, key, sizeof(struct evmc_bytes32));
+    jval = CopyDataToJava(jenv, value, sizeof(struct evmc_bytes32));
+
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress,
+                                                jkey, jval);
+    result = (enum evmc_storage_status)jresult;
+
     return result;
 }
 
@@ -161,38 +154,34 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
     char java_method_signature[] = "(I[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
-        assert(jresult != NULL);
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
+    assert(jresult != NULL);
 
-        evmc_uint256be* result_ptr =
-            (evmc_uint256be*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    evmc_uint256be* result_ptr = (evmc_uint256be*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+
     return result;
 }
 
@@ -203,31 +192,28 @@ static size_t get_code_size_fn(struct evmc_host_context* context, const evmc_add
     char java_method_signature[] = "(I[B)I";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jint jresult =
-            (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
-        result = (size_t)jresult;
-    }
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+
+    // call java method
+    jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress);
+    result = (size_t)jresult;
+
     return result;
 }
 
@@ -238,38 +224,35 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
     char java_method_signature[] = "(I[B)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
-        assert(jresult != NULL);
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
 
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jaddress);
+    assert(jresult != NULL);
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
+
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+
     return result;
 }
 
@@ -285,41 +268,39 @@ static size_t copy_code_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[BI)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jint jcode_offset = (jint)code_offset;
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
-                                                          jaddress, jcode_offset);
-        assert(jresult != NULL);
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jint jcode_offset = (jint)code_offset;
 
-        // copy jresult back to buffer_data
-        buffer_data = (uint8_t*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        (void)buffer_data;
-        assert(buffer_data != NULL);
+    // call java method
+    jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index,
+                                                      jaddress, jcode_offset);
+    assert(jresult != NULL);
 
-        result = get_code_size_fn(context, address) - code_offset;
+    // copy jresult back to buffer_data
+    buffer_data = (uint8_t*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    (void)buffer_data;
+    assert(buffer_data != NULL);
 
-        (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-    }
+    result = get_code_size_fn(context, address) - code_offset;
+
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+
     return result;
 }
 
@@ -331,33 +312,28 @@ static void selfdestruct_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[B)V";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jbeneficiary;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jbeneficiary;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jbeneficiary = CopyDataToJava(jenv, beneficiary, sizeof(struct evmc_address));
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress,
-                                     jbeneficiary);
-    }
-    return;
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jbeneficiary = CopyDataToJava(jenv, beneficiary, sizeof(struct evmc_address));
+
+    // call java method
+    (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jbeneficiary);
 }
 
 static struct evmc_result call_fn(struct evmc_host_context* context, const struct evmc_message* msg)
@@ -367,38 +343,36 @@ static struct evmc_result call_fn(struct evmc_host_context* context, const struc
     const char java_method_signature[] = "(ILjava/nio/ByteBuffer;)Ljava/nio/ByteBuffer;";
     JNIEnv* jenv = attach();
     assert(context != NULL);
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jobject jmsg;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jobject jmsg;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        jmsg = (*jenv)->NewDirectByteBuffer(jenv, (void*)msg, sizeof(struct evmc_message));
-        assert(jmsg != NULL);
+    // set java method params
+    jcontext_index = context->index;
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jmsg);
-        assert(jresult != NULL);
+    jmsg = (*jenv)->NewDirectByteBuffer(jenv, (void*)msg, sizeof(struct evmc_message));
+    assert(jmsg != NULL);
 
-        struct evmc_result* result_ptr =
-            (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
-    }
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jmsg);
+    assert(jresult != NULL);
+
+    struct evmc_result* result_ptr =
+        (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
+
     return result;
 }
 
@@ -409,33 +383,31 @@ static struct evmc_tx_context get_tx_context_fn(struct evmc_host_context* contex
     const char java_method_signature[] = "(I)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        // call java method
-        jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index);
-        assert(jresult != NULL);
+    // set java method params
+    jcontext_index = context->index;
 
-        struct evmc_tx_context* result_ptr =
-            (struct evmc_tx_context*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
-    }
+    // call java method
+    jobject jresult = (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index);
+    assert(jresult != NULL);
+
+    struct evmc_tx_context* result_ptr =
+        (struct evmc_tx_context*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
+
     return result;
 }
 
@@ -447,37 +419,34 @@ static evmc_bytes32 get_block_hash_fn(struct evmc_host_context* context, int64_t
     char java_method_signature[] = "(IJ)Ljava/nio/ByteBuffer;";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
-    {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jlong jnumber;
 
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jlong jnumber;
 
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
 
-        // set java method params
-        jcontext_index = context->index;
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
 
-        jnumber = (jlong)number;
+    // set java method params
+    jcontext_index = context->index;
 
-        // call java method
-        jobject jresult =
-            (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jnumber);
-        assert(jresult != NULL);
+    jnumber = (jlong)number;
 
-        evmc_bytes32* result_ptr =
-            (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
-        assert(result_ptr != NULL);
-        result = *result_ptr;
-    }
+    // call java method
+    jobject jresult =
+        (*jenv)->CallStaticObjectMethod(jenv, host_class, method, jcontext_index, jnumber);
+    assert(jresult != NULL);
+
+    evmc_bytes32* result_ptr = (struct evmc_bytes32*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
+    assert(result_ptr != NULL);
+    result = *result_ptr;
+
     return result;
 }
 
@@ -492,44 +461,40 @@ static void emit_log_fn(struct evmc_host_context* context,
     const char java_method_signature[] = "(I[B[BI[[BI)V";
     assert(context != NULL);
     JNIEnv* jenv = attach();
-    if (jenv != NULL)
+
+    jclass host_class;
+    jmethodID method;
+    jint jcontext_index;
+    jbyteArray jaddress;
+    jbyteArray jdata;
+    jobjectArray jtopics;
+
+    // get java class
+    host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
+    assert(host_class != NULL);
+
+    // get java method
+    method = (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
+    assert(method != NULL);
+
+    // set java method params
+    jcontext_index = context->index;
+    jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
+    jdata = CopyDataToJava(jenv, data, data_size);
+
+    jclass byte_type = (*jenv)->FindClass(jenv, "[B");
+    jtopics = (*jenv)->NewObjectArray(jenv, (jsize)topics_count, byte_type, NULL);
+    assert(jtopics != NULL);
+    for (size_t i = 0; i < topics_count; i++)
     {
-        jclass host_class;
-        jmethodID method;
-        jint jcontext_index;
-        jbyteArray jaddress;
-        jbyteArray jdata;
-        jobjectArray jtopics;
-
-        // get java class
-        host_class = (*jenv)->FindClass(jenv, "org/ethereum/evmc/Host");
-        assert(host_class != NULL);
-
-        // get java method
-        method =
-            (*jenv)->GetStaticMethodID(jenv, host_class, java_method_name, java_method_signature);
-        assert(method != NULL);
-
-        // set java method params
-        jcontext_index = context->index;
-        jaddress = CopyDataToJava(jenv, address, sizeof(struct evmc_address));
-        jdata = CopyDataToJava(jenv, data, data_size);
-
-        jclass byte_type = (*jenv)->FindClass(jenv, "[B");
-        jtopics = (*jenv)->NewObjectArray(jenv, (jsize)topics_count, byte_type, NULL);
-        assert(jtopics != NULL);
-        for (size_t i = 0; i < topics_count; i++)
-        {
-            jbyteArray jtopic = CopyDataToJava(jenv, topics[i].bytes, sizeof(struct evmc_bytes32));
-            (*jenv)->SetObjectArrayElement(jenv, jtopics, (jsize)i, jtopic);
-            (*jenv)->DeleteLocalRef(jenv, jtopic);
-        }
-
-        // call java method
-        (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jdata,
-                                     data_size, jtopics, topics_count);
+        jbyteArray jtopic = CopyDataToJava(jenv, topics[i].bytes, sizeof(struct evmc_bytes32));
+        (*jenv)->SetObjectArrayElement(jenv, jtopics, (jsize)i, jtopic);
+        (*jenv)->DeleteLocalRef(jenv, jtopic);
     }
-    return;
+
+    // call java method
+    (*jenv)->CallStaticIntMethod(jenv, host_class, method, jcontext_index, jaddress, jdata,
+                                 data_size, jtopics, topics_count);
 }
 
 const struct evmc_host_interface* evmc_java_get_host_interface()


### PR DESCRIPTION
Remove all the checks for jenv in the bindings code. If jenv is not there, it's better to crash.