### PR TITLE
ci: Fix Gomod integration test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -268,7 +268,7 @@ jobs:
           name: "Go module integration test"
           working_directory: test/gomod
           command: |
-            test -z "$CIRCLE_PR_USERNAME" || (echo "Skip for PRs from forks" && exit 0)
+            test -z "$CIRCLE_PR_USERNAME" || { echo "Skip for PRs from forks"; exit 0; }
 
             V=$CIRCLE_TAG
             if [ -z $V ]; then


### PR DESCRIPTION
The intention is to skip the test for external PRs as `go mod` does not work for fork repos. But the original script incorrectly used subshell instead of block of commands.

Proof it works now: https://app.circleci.com/pipelines/github/ethereum/evmc/1312/workflows/8dd17f41-baf4-46f8-9b4e-fe2d12e6f4b3/jobs/25360/parallel-runs/0/steps/0-104