### PR TITLE
examples: Convert example VM implementation to C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,17 +5,22 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 BinPackParameters: false
 BraceWrapping:
-  AfterClass:      true
+  AfterCaseLabel:        true
+  AfterClass:            true
   AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  true
-  AfterObjCDeclaration: true
-  AfterStruct:     true
-  AfterUnion:      true
-  BeforeCatch:     true
-  BeforeElse:      true
-  SplitEmptyFunction: false
+  AfterEnum:             true
+  AfterFunction:         true
+  AfterNamespace:        true
+  AfterStruct:           true
+  AfterUnion:            true
+  # AfterExternBlock:      true
+  BeforeCatch:           true
+  BeforeElse:            true
+  # BeforeLambdaBody:      true
+  # BeforeWhile:           true
+  SplitEmptyFunction:    false
+  SplitEmptyRecord:      false
+  SplitEmptyNamespace: false
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 ColumnLimit:     100

--- a/Doxyfile
+++ b/Doxyfile
@@ -102,7 +102,7 @@ WARN_LOGFILE           =
 INPUT                  = \
     include/evmc/ \
     docs/ \
-    examples/example_vm/example_vm.c
+    examples/example_vm/example_vm.cpp
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          =
 RECURSIVE              = NO

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -2,7 +2,7 @@
 // Copyright 2018-2020 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
-//go:generate gcc -shared ../../../examples/example_vm/example_vm.c -I../../../include -o example_vm.so
+//go:generate g++ -shared ../../../examples/example_vm/example_vm.cpp -I../../../include -o example_vm.so
 
 package evmc
 

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -41,7 +41,7 @@ func TestLoadConfigure(t *testing.T) {
 	}
 }
 
-func TestExecute(t *testing.T) {
+func TestExecuteEmptyCode(t *testing.T) {
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
@@ -49,13 +49,13 @@ func TestExecute(t *testing.T) {
 	h := Hash{}
 	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil, h)
 
-	if bytes.Compare(output, []byte("Welcome to Byzantium!")) != 0 {
-		t.Errorf("execution unexpected output: %s", output)
+	if bytes.Compare(output, []byte("")) != 0 {
+		t.Errorf("execution unexpected output: %x", output)
 	}
-	if gasLeft != 99 {
-		t.Error("execution gas left is incorrect")
+	if gasLeft != 999 {
+		t.Errorf("execution gas left is incorrect: %d", gasLeft)
 	}
-	if err != Failure {
-		t.Error("execution returned unexpected error")
+	if err != nil {
+		t.Errorf("execution returned unexpected error: %v", err)
 	}
 }

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -62,49 +62,57 @@ func (host *testHostContext) Call(kind CallKind,
 	return output, gas, Address{}, nil
 }
 
-func TestGetTxContext(t *testing.T) {
+func TestGetBlockNumberFromTxContext(t *testing.T) {
+	// Yul: mstore(0, number()) return(0, msize())
+	code := []byte("\x43\x60\x00\x52\x59\x60\x00\xf3")
+
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-	code := []byte("\x43\x60\x00\x52\x59\x60\x00\xf3")
-
 	addr := Address{}
 	h := Hash{}
 	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
 
-	if len(output) != 20 {
+	if len(output) != 32 {
 		t.Errorf("unexpected output size: %d", len(output))
 	}
-	if bytes.Compare(output[0:3], []byte("42\x00")) != 0 {
-		t.Errorf("execution unexpected output: %s", output)
+
+	// Should return value 42 (0x2a) as defined in GetTxContext().
+	expectedOutput := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x2a")
+	if bytes.Compare(output, expectedOutput) != 0 {
+		t.Errorf("execution unexpected output: %x", output)
 	}
-	if gasLeft != 50 {
+	if gasLeft != 94 {
 		t.Errorf("execution gas left is incorrect: %d", gasLeft)
 	}
 	if err != nil {
-		t.Error("execution returned unexpected error")
+		t.Errorf("execution returned unexpected error: %v", err)
 	}
 }
 
 func TestCall(t *testing.T) {
+	// pseudo-Yul: call(0, 0, 0, 0, 0, 0, 34) return(0, msize())
+	code := []byte("\x60\x22\x60\x00\x80\x80\x80\x80\x80\xf1\x59\x60\x00\xf3")
+
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-	code := []byte("\x60\x00\x80\x80\x80\x80\x80\x80\xf1")
-
 	addr := Address{}
 	h := Hash{}
 	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
 
+	if len(output) != 34 {
+		t.Errorf("execution unexpected output length: %d", len(output))
+	}
 	if bytes.Compare(output, []byte("output from testHostContext.Call()")) != 0 {
 		t.Errorf("execution unexpected output: %s", output)
 	}
-	if gasLeft != 99 {
+	if gasLeft != 89 {
 		t.Errorf("execution gas left is incorrect: %d", gasLeft)
 	}
 	if err != nil {
-		t.Error("execution returned unexpected error")
+		t.Errorf("execution returned unexpected error: %v", err)
 	}
 }

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
@@ -70,7 +70,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == 0);
+      assert (gasLeft == 199994);
     }
   }
 
@@ -100,7 +100,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == 0);
+      assert (gasLeft == 199994);
     }
   }
 
@@ -130,7 +130,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == gas / 2);
+      assert (gasLeft == 199994);
     }
   }
 
@@ -162,7 +162,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == gas / 2);
+      assert (gasLeft == 199991);
     }
   }
 
@@ -201,7 +201,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == 0); // gas - gas / 64);
+      assert (gasLeft == 199992);
     }
   }
 
@@ -229,7 +229,7 @@ final class EvmcTest {
       result.getInt(); // padding
       long gasLeft = result.getLong();
       assert (statusCode == 0);
-      assert (gasLeft == gas / 10);
+      assert (gasLeft == 199999);
     }
   }
 

--- a/circle.yml
+++ b/circle.yml
@@ -277,7 +277,7 @@ jobs:
             go get -v $(grep -o 'github.com/ethereum/evmc/v.*' ../../go.mod)@$V
             go mod tidy -v
             go mod graph
-            gcc -shared -I../../include ../../examples/example_vm/example_vm.c -o example-vm.so
+            g++ -shared -I../../include ../../examples/example_vm/example_vm.cpp -o example-vm.so
             go test -v
             go mod graph
 

--- a/docs/VM_Guide.md
+++ b/docs/VM_Guide.md
@@ -4,7 +4,7 @@
 
 ## An example
 
-You can start with [the example implementation of EVMC VM interface in C](@ref example_vm.c).
+You can start with [the example implementation of EVMC VM interface in C++](@ref example_vm.cpp).
 
 ## VM instance
 

--- a/examples/example_vm/CMakeLists.txt
+++ b/examples/example_vm/CMakeLists.txt
@@ -2,15 +2,17 @@
 # Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-add_library(example-vm SHARED example_vm.c example_vm.h)
+add_library(example-vm SHARED example_vm.cpp example_vm.h)
 add_library(evmc::example-vm ALIAS example-vm)
+target_compile_features(example-vm PRIVATE cxx_std_11)
 target_link_libraries(example-vm PRIVATE evmc::evmc)
 
-add_library(example-vm-static STATIC example_vm.c example_vm.h)
+add_library(example-vm-static STATIC example_vm.cpp example_vm.h)
 add_library(evmc::example-vm-static ALIAS example-vm-static)
+target_compile_features(example-vm-static PRIVATE cxx_std_11)
 target_link_libraries(example-vm-static PRIVATE evmc::evmc)
 
-set_source_files_properties(example_vm.c PROPERTIES
+set_source_files_properties(example_vm.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 
 if(EVMC_INSTALL)

--- a/examples/example_vm/example_vm.cpp
+++ b/examples/example_vm/example_vm.cpp
@@ -1,18 +1,15 @@
-/* EVMC: Ethereum Client-VM Connector API.
- * Copyright 2016-2019 The EVMC Authors.
- * Licensed under the Apache License, Version 2.0.
- */
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2016-2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
 
 /// @file
 /// Example implementation of the EVMC VM interface.
 ///
-/// This VM does not do anything useful except for showing
-/// how EVMC VM API should be implemented.
-/// The implementation is done in C only, but could be done in C++ in very
-/// similar way.
+/// This VM does not do anything useful except for showing how EVMC VM API
+/// should be implemented. The implementation uses the C API directly
+/// and is done in simple C++ for readability.
 
 #include "example_vm.h"
-
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,14 +19,14 @@
 /// The example VM instance struct extending the evmc_vm.
 struct example_vm
 {
-    struct evmc_vm instance;  ///< The base struct.
-    int verbose;              ///< The verbosity level.
+    evmc_vm instance;  ///< The base struct.
+    int verbose;       ///< The verbosity level.
 };
 
 /// The implementation of the evmc_vm::destroy() method.
-static void destroy(struct evmc_vm* vm)
+static void destroy(evmc_vm* vm)
 {
-    free(vm);
+    delete (struct example_vm*)vm;
 }
 
 /// The example implementation of the evmc_vm::get_capabilities() method.
@@ -82,7 +79,8 @@ static struct evmc_result execute(struct evmc_vm* instance,
                                   const uint8_t* code,
                                   size_t code_size)
 {
-    struct evmc_result ret = {.status_code = EVMC_INTERNAL_ERROR};
+    evmc_result ret = {};
+    ret.status_code = EVMC_INTERNAL_ERROR;
     if (code_size == 0)
     {
         // In case of empty code return a fancy error message.
@@ -218,17 +216,15 @@ static struct evmc_result execute(struct evmc_vm* instance,
 
 struct evmc_vm* evmc_create_example_vm()
 {
-    struct evmc_vm init = {
-        .abi_version = EVMC_ABI_VERSION,
-        .name = "example_vm",
-        .version = PROJECT_VERSION,
-        .destroy = destroy,
-        .execute = execute,
-        .get_capabilities = get_capabilities,
-        .set_option = set_option,
-    };
-    struct example_vm* vm = calloc(1, sizeof(struct example_vm));
-    struct evmc_vm* interface = &vm->instance;
-    memcpy(interface, &init, sizeof(init));
-    return interface;
+    example_vm* vm = new example_vm{evmc_vm{
+                                        EVMC_ABI_VERSION,
+                                        "example_vm",
+                                        PROJECT_VERSION,
+                                        destroy,
+                                        execute,
+                                        get_capabilities,
+                                        set_option,
+                                    },
+                                    0};
+    return &vm->instance;
 }

--- a/examples/example_vm/example_vm.cpp
+++ b/examples/example_vm/example_vm.cpp
@@ -5,53 +5,61 @@
 /// @file
 /// Example implementation of the EVMC VM interface.
 ///
-/// This VM does not do anything useful except for showing how EVMC VM API
-/// should be implemented. The implementation uses the C API directly
-/// and is done in simple C++ for readability.
+/// This VM implements a subset of EVM instructions in simplistic, incorrect and unsafe way:
+/// - memory bounds are not checked,
+/// - stack bounds are not checked,
+/// - most of the operations are done with 32-bit precision (instead of EVM 256-bit precision).
+/// Yet, it is capable of coping with some example EVM bytecode inputs, which is very useful
+/// in integration testing. The implementation is done in simple C++ for readability and uses
+/// pure C API and some C helpers.
 
 #include "example_vm.h"
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <evmc/evmc.h>
+#include <evmc/helpers.h>
+#include <evmc/instructions.h>
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
-
-/// The example VM instance struct extending the evmc_vm.
-struct example_vm
+/// The Example VM methods, helper and types are contained in the anonymous namespace.
+/// Technically, this limits the visibility of these elements (internal linkage).
+/// This is not strictly required, but is good practice and promotes position independent code.
+namespace
 {
-    evmc_vm instance;  ///< The base struct.
-    int verbose;       ///< The verbosity level.
+/// The example VM instance struct extending the evmc_vm.
+struct ExampleVM : evmc_vm
+{
+    int verbose = 0;  ///< The verbosity level.
+    ExampleVM();      ///< Constructor to initialize the evmc_vm struct.
 };
 
 /// The implementation of the evmc_vm::destroy() method.
-static void destroy(evmc_vm* vm)
+void destroy(evmc_vm* instance)
 {
-    delete (struct example_vm*)vm;
+    delete static_cast<ExampleVM*>(instance);
 }
 
 /// The example implementation of the evmc_vm::get_capabilities() method.
-static evmc_capabilities_flagset get_capabilities(struct evmc_vm* vm)
+evmc_capabilities_flagset get_capabilities(evmc_vm* /*instance*/)
 {
-    (void)vm;
-    return EVMC_CAPABILITY_EVM1 | EVMC_CAPABILITY_EWASM;
+    return EVMC_CAPABILITY_EVM1;
 }
 
 /// Example VM options.
 ///
 /// The implementation of the evmc_vm::set_option() method.
 /// VMs are allowed to omit this method implementation.
-static enum evmc_set_option_result set_option(struct evmc_vm* instance,
-                                              const char* name,
-                                              const char* value)
+enum evmc_set_option_result set_option(evmc_vm* instance, const char* name, const char* value)
 {
-    struct example_vm* vm = (struct example_vm*)instance;
-    if (strcmp(name, "verbose") == 0)
+    ExampleVM* vm = static_cast<ExampleVM*>(instance);
+    if (std::strcmp(name, "verbose") == 0)
     {
-        if (!value)
+        if (value == nullptr)
             return EVMC_SET_OPTION_INVALID_VALUE;
 
-        char* end = NULL;
-        long int v = strtol(value, &end, 0);
+        char* end = nullptr;
+        long int v = std::strtol(value, &end, 0);
         if (end == value)  // Parsing the value failed.
             return EVMC_SET_OPTION_INVALID_VALUE;
         if (v > 9 || v < -1)  // Not in the valid range.
@@ -63,147 +71,274 @@ static enum evmc_set_option_result set_option(struct evmc_vm* instance,
     return EVMC_SET_OPTION_INVALID_NAME;
 }
 
-/// The implementation of the evmc_result::release() method that frees
-/// the output buffer attached to the result object.
-static void free_result_output_data(const struct evmc_result* result)
+/// The Example VM stack representation.
+struct Stack
 {
-    free((uint8_t*)result->output_data);
+    evmc_uint256be items[1024];       ///< The array of stack items, uninitialized.
+    evmc_uint256be* pointer = items;  ///< The pointer to the currently first empty stack slot.
+
+    /// Pops an item from the top of the stack.
+    evmc_uint256be pop() { return *--pointer; }
+
+    /// Pushes an item to the top of the stack.
+    void push(evmc_uint256be value) { *pointer++ = value; }
+};
+
+/// The Example VM memory representation.
+struct Memory
+{
+    uint32_t size = 0;        ///< The current size of the memory.
+    uint8_t data[1024] = {};  ///< The fixed-size memory buffer.
+
+    /// Expands the "active" EVM memory by the given memory region defined by
+    /// @p offset and @p region_size. The region of size 0 also expands the memory
+    /// (what is different behavior than EVM specifies).
+    /// Returns pointer to the beginning of the region in the memory,
+    /// or nullptr if the memory cannot be expanded to the required size.
+    uint8_t* expand(uint32_t offset, uint32_t region_size)
+    {
+        uint32_t new_size = offset + region_size;
+        if (new_size > sizeof(data))
+            return nullptr;  // Cannot expand more than fixed max memory size.
+
+        if (new_size > size)
+            size = new_size;  // Update current memory size.
+
+        return &data[offset];
+    }
+
+    /// Stores the given value bytes in the memory at the given offset.
+    /// The Memory::size is updated accordingly.
+    /// Returns true if successful, false if the memory cannot be expanded to the required size.
+    bool store(uint32_t offset, const uint8_t* value_data, uint32_t value_size)
+    {
+        uint8_t* p = expand(offset, value_size);
+        if (p == nullptr)
+            return false;
+
+        std::memcpy(p, value_data, value_size);
+        return true;
+    }
+};
+
+/// Creates 256-bit value out of 32-bit input.
+inline evmc_uint256be to_uint256(uint32_t x)
+{
+    evmc_uint256be value = {};
+    value.bytes[31] = static_cast<uint8_t>(x);
+    value.bytes[30] = static_cast<uint8_t>(x >> 8);
+    value.bytes[29] = static_cast<uint8_t>(x >> 16);
+    value.bytes[28] = static_cast<uint8_t>(x >> 24);
+    return value;
 }
 
-/// The example implementation of the evmc_vm::execute() method.
-static struct evmc_result execute(struct evmc_vm* instance,
-                                  const struct evmc_host_interface* host,
-                                  struct evmc_host_context* context,
-                                  enum evmc_revision rev,
-                                  const struct evmc_message* msg,
-                                  const uint8_t* code,
-                                  size_t code_size)
+/// Creates 256-bit value out of an 160-bit address.
+inline evmc_uint256be to_uint256(evmc_address address)
 {
-    evmc_result ret = {};
-    ret.status_code = EVMC_INTERNAL_ERROR;
-    if (code_size == 0)
+    evmc_uint256be value = {};
+    size_t offset = sizeof(value) - sizeof(address);
+    std::memcpy(&value.bytes[offset], address.bytes, sizeof(address.bytes));
+    return value;
+}
+
+/// Truncates 256-bit value to 32-bit value.
+inline uint32_t to_uint32(evmc_uint256be value)
+{
+    return (uint32_t{value.bytes[28]} << 24) | (uint32_t{value.bytes[29]} << 16) |
+           (uint32_t{value.bytes[30]} << 8) | (uint32_t{value.bytes[31]});
+}
+
+/// Truncates 256-bit value to 160-bit address.
+inline evmc_address to_address(evmc_uint256be value)
+{
+    evmc_address address = {};
+    size_t offset = sizeof(value) - sizeof(address);
+    std::memcpy(address.bytes, &value.bytes[offset], sizeof(address.bytes));
+    return address;
+}
+
+
+/// The example implementation of the evmc_vm::execute() method.
+evmc_result execute(evmc_vm* instance,
+                    const evmc_host_interface* host,
+                    evmc_host_context* context,
+                    enum evmc_revision rev,
+                    const evmc_message* msg,
+                    const uint8_t* code,
+                    size_t code_size)
+{
+    ExampleVM* vm = static_cast<ExampleVM*>(instance);
+
+    if (vm->verbose > 0)
+        std::puts("execution started\n");
+
+    int64_t gas_left = msg->gas;
+    Stack stack;
+    Memory memory;
+
+    for (size_t pc = 0; pc < code_size; ++pc)
     {
-        // In case of empty code return a fancy error message.
-        const char* error = rev == EVMC_BYZANTIUM ? "Welcome to Byzantium!" : "Hello Ethereum!";
-        ret.output_data = (const uint8_t*)error;
-        ret.output_size = strlen(error);
-        ret.status_code = EVMC_FAILURE;
-        ret.gas_left = msg->gas / 10;
-        ret.release = NULL;  // We don't need to release the constant messages.
-        return ret;
-    }
+        // Check remaining gas, assume each instruction costs 1.
+        gas_left -= 1;
+        if (gas_left < 0)
+            return evmc_make_result(EVMC_OUT_OF_GAS, 0, nullptr, 0);
 
-    struct example_vm* vm = (struct example_vm*)instance;
-
-    // Simulate executing by checking for some code patterns.
-    // Solidity inline assembly is used in the examples instead of EVM bytecode.
-
-    // Assembly: `{ mstore(0, address()) return(0, msize()) }`.
-    const char return_address[] = "\x30\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: `{ sstore(0, add(sload(0), 1)) }`
-    const char counter[] = "\x60\x01\x60\x00\x54\x01\x60\x00\x55";
-
-    // Assembly: `{ mstore(0, number()) return(0, msize()) }`
-    const char return_block_number[] = "\x43\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: `{ sstore(0, number()) mstore(0, number()) return(0, msize()) }`
-    const char save_return_block_number[] = "\x43\x60\x00\x55\x43\x60\x00\x52\x59\x60\x00\xf3";
-
-    // Assembly: PUSH(0) 6x DUP1 CALL
-    const char make_a_call[] = "\x60\x00\x80\x80\x80\x80\x80\x80\xf1";
-
-    if (msg->kind == EVMC_CREATE)
-    {
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 10;
-        return ret;
-    }
-    else if (code_size == (sizeof(return_address) - 1) &&
-             strncmp((const char*)code, return_address, code_size) == 0)
-    {
-        static const size_t address_size = sizeof(msg->destination);
-        uint8_t* output_data = (uint8_t*)malloc(address_size);
-        if (!output_data)
+        switch (code[pc])
         {
-            // malloc failed, report internal error.
-            ret.status_code = EVMC_INTERNAL_ERROR;
-            return ret;
+        default:
+            return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+
+        case OP_STOP:
+            return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
+
+        case OP_ADD:
+        {
+            uint32_t a = to_uint32(stack.pop());
+            uint32_t b = to_uint32(stack.pop());
+            uint32_t sum = a + b;
+            stack.push(to_uint256(sum));
+            break;
         }
-        memcpy(output_data, &msg->destination, address_size);
-        ret.status_code = EVMC_SUCCESS;
-        ret.output_data = output_data;
-        ret.output_size = address_size;
-        ret.release = &free_result_output_data;
-        return ret;
+
+        case OP_ADDRESS:
+        {
+            evmc_uint256be value = to_uint256(msg->destination);
+            stack.push(value);
+            break;
+        }
+
+        case OP_CALLDATALOAD:
+        {
+            uint32_t offset = to_uint32(stack.pop());
+            evmc_uint256be value = {};
+
+            if (offset < msg->input_size)
+            {
+                size_t copy_size = std::min(msg->input_size - offset, sizeof(value));
+                std::memcpy(value.bytes, &msg->input_data[offset], copy_size);
+            }
+
+            stack.push(value);
+            break;
+        }
+
+        case OP_NUMBER:
+        {
+            evmc_uint256be value =
+                to_uint256(static_cast<uint32_t>(host->get_tx_context(context).block_number));
+            stack.push(value);
+            break;
+        }
+
+        case OP_MSTORE:
+        {
+            uint32_t index = to_uint32(stack.pop());
+            evmc_uint256be value = stack.pop();
+            if (!memory.store(index, value.bytes, sizeof(value)))
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+            break;
+        }
+
+        case OP_SLOAD:
+        {
+            evmc_uint256be index = stack.pop();
+            evmc_uint256be value = host->get_storage(context, &msg->destination, &index);
+            stack.push(value);
+            break;
+        }
+
+        case OP_SSTORE:
+        {
+            evmc_uint256be index = stack.pop();
+            evmc_uint256be value = stack.pop();
+            host->set_storage(context, &msg->destination, &index, &value);
+            break;
+        }
+
+        case OP_MSIZE:
+        {
+            evmc_uint256be value = to_uint256(memory.size);
+            stack.push(value);
+            break;
+        }
+
+        case OP_PUSH1:
+        {
+            ++pc;
+            evmc_uint256be value = to_uint256(code[pc]);
+            stack.push(value);
+            break;
+        }
+
+        case OP_DUP1:
+        {
+            evmc_uint256be value = stack.pop();
+            stack.push(value);
+            stack.push(value);
+            break;
+        }
+
+        case OP_CALL:
+        {
+            evmc_message call_msg = {};
+            call_msg.gas = to_uint32(stack.pop());
+            call_msg.destination = to_address(stack.pop());
+            call_msg.value = stack.pop();
+
+            uint32_t call_input_offset = to_uint32(stack.pop());
+            uint32_t call_input_size = to_uint32(stack.pop());
+            call_msg.input_data = memory.expand(call_input_offset, call_input_size);
+            call_msg.input_size = call_input_size;
+
+            uint32_t call_output_offset = to_uint32(stack.pop());
+            uint32_t call_output_size = to_uint32(stack.pop());
+            uint8_t* call_output_ptr = memory.expand(call_output_offset, call_output_size);
+
+            if (call_msg.input_data == nullptr || call_output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            evmc_result call_result = host->call(context, &call_msg);
+
+            evmc_uint256be value = to_uint256(call_result.status_code == EVMC_SUCCESS);
+            stack.push(value);
+
+            if (call_output_size > call_result.output_size)
+                call_output_size = static_cast<uint32_t>(call_result.output_size);
+            memory.store(call_output_offset, call_result.output_data, call_output_size);
+
+            if (call_result.release != nullptr)
+                call_result.release(&call_result);
+            break;
+        }
+
+        case OP_RETURN:
+        {
+            uint32_t output_offset = to_uint32(stack.pop());
+            uint32_t output_size = to_uint32(stack.pop());
+            uint8_t* output_ptr = memory.expand(output_offset, output_size);
+            if (output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            return evmc_make_result(EVMC_SUCCESS, gas_left, output_ptr, output_size);
+        }
+
+        case OP_REVERT:
+        {
+            if (rev < EVMC_BYZANTIUM)
+                return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+
+            uint32_t output_offset = to_uint32(stack.pop());
+            uint32_t output_size = to_uint32(stack.pop());
+            uint8_t* output_ptr = memory.expand(output_offset, output_size);
+            if (output_ptr == nullptr)
+                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+
+            return evmc_make_result(EVMC_REVERT, gas_left, output_ptr, output_size);
+        }
+        }
     }
-    else if (code_size == (sizeof(counter) - 1) &&
-             strncmp((const char*)code, counter, code_size) == 0)
-    {
-        const evmc_bytes32 key = {{0}};
-        evmc_bytes32 value = host->get_storage(context, &msg->destination, &key);
-        value.bytes[31]++;
-        host->set_storage(context, &msg->destination, &key, &value);
-        ret.status_code = EVMC_SUCCESS;
-        return ret;
-    }
-    else if (code_size == (sizeof(return_block_number) - 1) &&
-             strncmp((const char*)code, return_block_number, code_size) == 0)
-    {
-        const struct evmc_tx_context tx_context = host->get_tx_context(context);
-        const size_t output_size = 20;
 
-        uint8_t* output_data = (uint8_t*)calloc(1, output_size);
-        snprintf((char*)output_data, output_size, "%u", (unsigned)tx_context.block_number);
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 2;
-        ret.output_data = output_data;
-        ret.output_size = output_size;
-        ret.release = &free_result_output_data;
-        return ret;
-    }
-    else if (code_size == (sizeof(save_return_block_number) - 1) &&
-             strncmp((const char*)code, save_return_block_number, code_size) == 0)
-    {
-        const struct evmc_tx_context tx_context = host->get_tx_context(context);
-        const size_t output_size = 20;
-
-        // Store block number.
-        const evmc_bytes32 key = {{0}};
-        evmc_bytes32 value = {{0}};
-        // NOTE: assume block number is <= 255
-        value.bytes[31] = (uint8_t)tx_context.block_number;
-        host->set_storage(context, &msg->destination, &key, &value);
-
-        // Return block number.
-        uint8_t* output_data = (uint8_t*)calloc(1, output_size);
-        snprintf((char*)output_data, output_size, "%u", (unsigned)tx_context.block_number);
-        ret.status_code = EVMC_SUCCESS;
-        ret.gas_left = msg->gas / 2;
-        ret.output_data = output_data;
-        ret.output_size = output_size;
-        ret.release = &free_result_output_data;
-        return ret;
-    }
-    else if (code_size == (sizeof(make_a_call) - 1) &&
-             strncmp((const char*)code, make_a_call, code_size) == 0)
-    {
-        struct evmc_message call_msg;
-        memset(&call_msg, 0, sizeof(call_msg));
-        call_msg.kind = EVMC_CALL;
-        call_msg.depth = msg->depth + 1;
-        call_msg.gas = msg->gas - (msg->gas / 64);
-        call_msg.sender = msg->destination;
-        return host->call(context, &call_msg);
-    }
-
-    ret.status_code = EVMC_FAILURE;
-    ret.gas_left = 0;
-
-    if (vm->verbose)
-        printf("Execution done.\n");
-
-    return ret;
+    return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
 }
 
 
@@ -214,17 +349,13 @@ static struct evmc_result execute(struct evmc_vm* instance,
 #endif
 /// @endcond
 
-struct evmc_vm* evmc_create_example_vm()
+ExampleVM::ExampleVM()
+  : evmc_vm{EVMC_ABI_VERSION, "example_vm",       PROJECT_VERSION, ::destroy,
+            ::execute,        ::get_capabilities, ::set_option}
+{}
+}  // namespace
+
+extern "C" evmc_vm* evmc_create_example_vm()
 {
-    example_vm* vm = new example_vm{evmc_vm{
-                                        EVMC_ABI_VERSION,
-                                        "example_vm",
-                                        PROJECT_VERSION,
-                                        destroy,
-                                        execute,
-                                        get_capabilities,
-                                        set_option,
-                                    },
-                                    0};
-    return &vm->instance;
+    return new ExampleVM;
 }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -656,7 +656,7 @@ public:
         return (get_capabilities() & static_cast<evmc_capabilities_flagset>(capability)) != 0;
     }
 
-    /// @copydoc evmc::vm::get_capabilities
+    /// @copydoc evmc_vm::get_capabilities
     evmc_capabilities_flagset get_capabilities() const noexcept
     {
         return m_instance->get_capabilities(m_instance);

--- a/test/gomod/README
+++ b/test/gomod/README
@@ -5,5 +5,5 @@ Usage:
     go mod init evmc.ethereum.org/evmc_use
     go get github.com/ethereum/evmc/v7@<commit-hash-to-be-tested>
     go mod tidy
-    gcc -shared -I../../include ../../examples/example_vm/example_vm.c -o example-vm.so
+    gcc -shared -I../../include ../../examples/example_vm/example_vm.cpp -o example-vm.so
     go test

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2019 The EVMC Authors.
+# Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 set(prefix ${PROJECT_NAME}/evmc-run)
@@ -10,7 +10,7 @@ add_test(
 )
 set_tests_properties(
     ${prefix}/example1 PROPERTIES PASS_REGULAR_EXPRESSION
-    "Result: +success[\r\n]+Gas used: +99[\r\n]+Output: +0000000000000000000000000000000000000000[\r\n]"
+    "Result: +success[\r\n]+Gas used: +6[\r\n]+Output: +0000000000000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 
 get_property(tools_tests DIRECTORY PROPERTY TESTS)

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_definitions(loader-mocked PRIVATE EVMC_LOADER_MOCK=1)
 add_executable(
     evmc-unittests
     cpp_test.cpp
+    example_vm_test.cpp
     helpers_test.cpp
     instructions_test.cpp
     loader_mock.h
@@ -34,6 +35,7 @@ target_link_libraries(
     evmc::instructions
     evmc::evmc_cpp
     evmc::tool-commands
+    evmc::tool-utils
     GTest::gtest_main
 )
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -418,8 +418,11 @@ TEST(cpp, vm)
     EXPECT_NE(vm.version()[0], 0);
 
     const auto host = evmc_host_interface{};
-    auto res = vm.execute(host, nullptr, EVMC_MAX_REVISION, {}, nullptr, 0);
-    EXPECT_EQ(res.status_code, EVMC_FAILURE);
+    auto msg = evmc_message{};
+    msg.gas = 1;
+    auto res = vm.execute(host, nullptr, EVMC_MAX_REVISION, msg, nullptr, 0);
+    EXPECT_EQ(res.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(res.gas_left, 1);
 }
 
 TEST(cpp, vm_capabilities)
@@ -427,10 +430,10 @@ TEST(cpp, vm_capabilities)
     const auto vm = evmc::VM{evmc_create_example_vm()};
 
     EXPECT_TRUE(vm.get_capabilities() & EVMC_CAPABILITY_EVM1);
-    EXPECT_TRUE(vm.get_capabilities() & EVMC_CAPABILITY_EWASM);
+    EXPECT_FALSE(vm.get_capabilities() & EVMC_CAPABILITY_EWASM);
     EXPECT_FALSE(vm.get_capabilities() & EVMC_CAPABILITY_PRECOMPILES);
     EXPECT_TRUE(vm.has_capability(EVMC_CAPABILITY_EVM1));
-    EXPECT_TRUE(vm.has_capability(EVMC_CAPABILITY_EWASM));
+    EXPECT_FALSE(vm.has_capability(EVMC_CAPABILITY_EWASM));
     EXPECT_FALSE(vm.has_capability(EVMC_CAPABILITY_PRECOMPILES));
 }
 
@@ -554,8 +557,9 @@ TEST(cpp, vm_execute_with_null_host)
 
     auto vm = evmc::VM{evmc_create_example_vm()};
     evmc_message msg{};
-    auto res = vm.execute(host, EVMC_MAX_REVISION, msg, nullptr, 0);
-    EXPECT_EQ(res.status_code, EVMC_FAILURE);
+    auto res = vm.execute(host, EVMC_FRONTIER, msg, nullptr, 0);
+    EXPECT_EQ(res.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(res.gas_left, 0);
 }
 
 TEST(cpp, host)

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -1,0 +1,195 @@
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include "../../examples/example_vm/example_vm.h"
+#include <evmc/evmc.hpp>
+#include <evmc/mocked_host.hpp>
+#include <tools/utils/utils.hpp>
+#include <gtest/gtest.h>
+#include <cstring>
+
+using namespace evmc::literals;
+
+namespace
+{
+struct Output
+{
+    evmc::bytes bytes;
+
+    explicit Output(const char* output_hex) noexcept : bytes{evmc::from_hex(output_hex)} {}
+
+    friend bool operator==(const evmc::result& result, const Output& expected) noexcept
+    {
+        return expected.bytes.compare(0, evmc::bytes::npos, result.output_data,
+                                      result.output_size) == 0;
+    }
+};
+
+auto vm = evmc::VM{evmc_create_example_vm()};
+
+class example_vm : public testing::Test
+{
+protected:
+    evmc_revision rev = EVMC_MAX_REVISION;
+    evmc::MockedHost host;
+    evmc_message msg{};
+
+    example_vm() noexcept
+    {
+        msg.sender = 0x5000000000000000000000000000000000000005_address;
+        msg.destination = 0xd00000000000000000000000000000000000000d_address;
+    }
+
+    evmc::result execute_in_example_vm(int64_t gas,
+                                       const char* code_hex,
+                                       const char* input_hex = "") noexcept
+    {
+        const auto code = evmc::from_hex(code_hex);
+        const auto input = evmc::from_hex(input_hex);
+
+        msg.gas = gas;
+        msg.input_data = input.data();
+        msg.input_size = input.size();
+
+        return vm.execute(host, rev, msg, code.data(), code.size());
+    }
+};
+
+
+}  // namespace
+
+TEST_F(example_vm, empty_code)
+{
+    const auto r = execute_in_example_vm(999, "");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 999);
+    EXPECT_EQ(r.output_size, size_t{0});
+}
+
+TEST_F(example_vm, return_address)
+{
+    // Yul: mstore(0, address()) return(12, 20)
+    const auto r = execute_in_example_vm(6, "306000526014600cf3");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output("d00000000000000000000000000000000000000d"));
+}
+
+TEST_F(example_vm, counter_in_storage)
+{
+    // Yul: sstore(0, add(sload(0), 1)) stop()
+    auto& storage_value = host.accounts[msg.destination].storage[{}].value;
+    storage_value = 0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
+    const auto r = execute_in_example_vm(10, "60016000540160005500");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 3);
+    EXPECT_EQ(r, Output(""));
+    EXPECT_EQ(storage_value,
+              0x00000000000000000000000000000000000000000000000000000000000000bc_bytes32);
+}
+
+TEST_F(example_vm, return_block_number)
+{
+    // Yul: mstore(0, number()) return(0, msize())
+    host.tx_context.block_number = 0xb4;
+    const auto r = execute_in_example_vm(7, "43600052596000f3");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 1);
+    EXPECT_EQ(r, Output("00000000000000000000000000000000000000000000000000000000000000b4"));
+}
+
+TEST_F(example_vm, return_out_of_memory)
+{
+    // Yul: return(add(255, 254), add(add(255, 254), 253))
+    const auto r = execute_in_example_vm(10, "60fd60fe60ff010160fe60ff01f3");
+    EXPECT_EQ(r.status_code, EVMC_FAILURE);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output(""));
+}
+
+TEST_F(example_vm, revert_out_of_memory)
+{
+    // Yul: revert(add(255, 254), add(add(255, 254), 253))
+    const auto r = execute_in_example_vm(10, "60fd60fe60ff010160fe60ff01fd");
+    EXPECT_EQ(r.status_code, EVMC_FAILURE);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output(""));
+}
+
+TEST_F(example_vm, revert_block_number)
+{
+    // Yul: mstore(0, number()) revert(0, 32)
+    host.tx_context.block_number = 0xb4;
+    const auto r = execute_in_example_vm(7, "4360005260206000fd");
+    EXPECT_EQ(r.status_code, EVMC_REVERT);
+    EXPECT_EQ(r.gas_left, 1);
+    EXPECT_EQ(r, Output("00000000000000000000000000000000000000000000000000000000000000b4"));
+}
+
+TEST_F(example_vm, revert_undefined)
+{
+    rev = EVMC_FRONTIER;
+    const auto r = execute_in_example_vm(100, "fd");
+    EXPECT_EQ(r.status_code, EVMC_UNDEFINED_INSTRUCTION);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output(""));
+}
+
+TEST_F(example_vm, call)
+{
+    // pseudo-Yul: call(3, 3, 3, 3, 3, 3, 3) return(0, msize())
+    const auto expected_output = evmc::from_hex("aabbcc");
+    host.call_result.output_data = expected_output.data();
+    host.call_result.output_size = expected_output.size();
+    const auto r = execute_in_example_vm(100, "6003808080808080f1596000f3");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 89);
+    EXPECT_EQ(r, Output("000000aabbcc"));
+    ASSERT_EQ(host.recorded_calls.size(), size_t{1});
+    EXPECT_EQ(host.recorded_calls[0].flags, uint32_t{0});
+    EXPECT_EQ(host.recorded_calls[0].gas, 3);
+    EXPECT_EQ(host.recorded_calls[0].value,
+              0x0000000000000000000000000000000000000000000000000000000000000003_bytes32);
+    EXPECT_EQ(host.recorded_calls[0].destination,
+              0x0000000000000000000000000000000000000003_address);
+    EXPECT_EQ(host.recorded_calls[0].input_size, size_t{3});
+}
+
+TEST_F(example_vm, calldataload_full)
+{
+    // Yul: mstore(0, calldataload(2)) return(0, msize())
+    const auto r = execute_in_example_vm(
+        7, "600235600052596000f3",
+        "4444000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"));
+}
+
+TEST_F(example_vm, calldataload_partial)
+{
+    // Yul: mstore(0, calldataload(0)) return(0, msize())
+    const auto r = execute_in_example_vm(7, "600035600052596000f3", "aabbccdd");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output("aabbccdd00000000000000000000000000000000000000000000000000000000"));
+}
+
+TEST_F(example_vm, calldataload_empty)
+{
+    // Yul: mstore(0, calldataload(4)) return(0, msize())
+    const auto r = execute_in_example_vm(7, "600435600052596000f3", "aabbccdd");
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output("0000000000000000000000000000000000000000000000000000000000000000"));
+}
+
+TEST_F(example_vm, mstore_out_of_memory)
+{
+    // Yul: mstore(add(add(255, 254), add(253, 252)), 1)
+    const auto r = execute_in_example_vm(9, "600160fc60fd0160fe60ff010152");
+    EXPECT_EQ(r.status_code, EVMC_FAILURE);
+    EXPECT_EQ(r.gas_left, 0);
+    EXPECT_EQ(r, Output(""));
+}

--- a/test/unittests/tool_commands_test.cpp
+++ b/test/unittests/tool_commands_test.cpp
@@ -33,7 +33,7 @@ TEST(tool_commands, run_empty_code)
 
     const auto exit_code = cmd::run(vm, EVMC_FRONTIER, 1, "", out);
     EXPECT_EQ(exit_code, 0);
-    EXPECT_EQ(out.str(), out_pattern("Frontier", 1, "failure", 1));
+    EXPECT_EQ(out.str(), out_pattern("Frontier", 1, "success", 0, ""));
 }
 
 TEST(tool_commands, run_return_my_address)
@@ -43,6 +43,7 @@ TEST(tool_commands, run_return_my_address)
 
     const auto exit_code = cmd::run(vm, EVMC_HOMESTEAD, 200, "30600052596000f3", out);
     EXPECT_EQ(exit_code, 0);
-    EXPECT_EQ(out.str(), out_pattern("Homestead", 200, "success", 200,
-                                     "0000000000000000000000000000000000000000"));
+    EXPECT_EQ(out.str(),
+              out_pattern("Homestead", 200, "success", 6,
+                          "0000000000000000000000000000000000000000000000000000000000000000"));
 }


### PR DESCRIPTION
This allows simpler and much readable implementation. The goal is to stay close to C.
This is going to be useful to test `evmc run` for options like `--input` and `--deploy`.

This however requires users like Go and Java to build the `example-vm.so` as C++. This bumps runtime requirements to include C++ standard library.

Fixes #364.