### PR TITLE
java: clean up memory handling

### DIFF
--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -71,7 +71,10 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
     // call java method
     jboolean jresult =
         (*jenv)->CallStaticBooleanMethod(jenv, host_class, method, context->index, jaddress);
-    // FIXME: release jaddress?
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, JNI_ABORT);
+    (*jenv)->DeleteLocalRef(jenv, jaddress);
+    (*jenv)->DeleteLocalRef(jenv, method);
+    (*jenv)->DeleteLocalRef(jenv, host_class);
     return jresult != 0;
 }
 

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -169,7 +169,7 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
     evmc_uint256be result;
     CopyFromByteBuffer(jenv, jresult, &result, sizeof(evmc_uint256be));
 
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, JNI_ABORT);
 
     return result;
 }
@@ -228,7 +228,7 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
     evmc_bytes32 result;
     CopyFromByteBuffer(jenv, jresult, &result, sizeof(evmc_bytes32));
 
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, JNI_ABORT);
 
     return result;
 }
@@ -279,7 +279,7 @@ static size_t copy_code_fn(struct evmc_host_context* context,
             memcpy(buffer_data, code + code_offset, length);
     }
 
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
+    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, JNI_ABORT);
 
     return length;
 }

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -71,6 +71,7 @@ static bool account_exists_fn(struct evmc_host_context* context, const evmc_addr
     // call java method
     jboolean jresult =
         (*jenv)->CallStaticBooleanMethod(jenv, host_class, method, context->index, jaddress);
+    // FIXME: release jaddress?
     return jresult != 0;
 }
 
@@ -104,6 +105,7 @@ static evmc_bytes32 get_storage_fn(struct evmc_host_context* context,
 
     evmc_bytes32 result;
     CopyFromByteBuffer(jenv, jresult, &result, sizeof(evmc_bytes32));
+    // FIXME: release jaddress and jkey?
     return result;
 }
 
@@ -135,6 +137,7 @@ static enum evmc_storage_status set_storage_fn(struct evmc_host_context* context
     // call java method
     jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, context->index, jaddress,
                                                 jkey, jval);
+    // FIXME: release jaddress, jkey, jval?
     return (enum evmc_storage_status)jresult;
 }
 
@@ -193,6 +196,7 @@ static size_t get_code_size_fn(struct evmc_host_context* context, const evmc_add
 
     // call java method
     jint jresult = (*jenv)->CallStaticIntMethod(jenv, host_class, method, context->index, jaddress);
+    // FIXME: release jaddress?
     return (size_t)jresult;
 }
 
@@ -305,6 +309,7 @@ static void selfdestruct_fn(struct evmc_host_context* context,
 
     // call java method
     (*jenv)->CallStaticIntMethod(jenv, host_class, method, context->index, jaddress, jbeneficiary);
+    // FIXME: release jaddress and jbeneficiary?
 }
 
 static struct evmc_result call_fn(struct evmc_host_context* context, const struct evmc_message* msg)
@@ -430,6 +435,7 @@ static void emit_log_fn(struct evmc_host_context* context,
     // call java method
     (*jenv)->CallStaticIntMethod(jenv, host_class, method, context->index, jaddress, jdata,
                                  data_size, jtopics, topics_count);
+    // FIXME: release jaddress and jdata?
 }
 
 const struct evmc_host_interface* evmc_java_get_host_interface()


### PR DESCRIPTION
Apparently the bindings should be leaking a lot of memory because references are never released, see https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/jni_refs.html and https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Release_PrimitiveType_ArrayElements_routines