### PR TITLE
cmake: Extract evmc::tool-utils out of evmc::tool

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2019 The EVMC Authors.
+# Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 add_subdirectory(evmc)
+add_subdirectory(utils)
 add_subdirectory(vmtester)

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -1,15 +1,15 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2019 The EVMC Authors.
+# Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 hunter_add_package(CLI11)
 find_package(CLI11 REQUIRED)
 
-add_executable(evmc-tool main.cpp utils.cpp utils.hpp)
+add_executable(evmc-tool main.cpp)
 add_executable(evmc::tool ALIAS evmc-tool)
 set_target_properties(evmc-tool PROPERTIES
     OUTPUT_NAME evmc
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set_source_files_properties(main.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
-target_link_libraries(evmc-tool PRIVATE evmc::mocked_host evmc::loader CLI11::CLI11)
+target_link_libraries(evmc-tool PRIVATE evmc::tool-utils evmc::mocked_host evmc::loader CLI11::CLI11)

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -5,8 +5,7 @@
 #include <CLI/CLI.hpp>
 #include <evmc/loader.h>
 #include <evmc/mocked_host.hpp>
-
-#include "utils.hpp"
+#include <tools/utils/utils.hpp>
 
 int main(int argc, const char** argv)
 {

--- a/tools/utils/CMakeLists.txt
+++ b/tools/utils/CMakeLists.txt
@@ -1,0 +1,9 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2020 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+add_library(tool-utils STATIC utils.cpp utils.hpp)
+add_library(evmc::tool-utils ALIAS tool-utils)
+target_compile_features(tool-utils PUBLIC cxx_std_14)
+target_include_directories(tool-utils PUBLIC ${PROJECT_SOURCE_DIR})
+target_link_libraries(tool-utils PUBLIC evmc::evmc)

--- a/tools/utils/utils.cpp
+++ b/tools/utils/utils.cpp
@@ -1,8 +1,8 @@
-// evmone: Fast Ethereum Virtual Machine implementation
-// Copyright 2018-2019 The EVMC Authors.
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2018-2020 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
-#include "utils.hpp"
+#include <tools/utils/utils.hpp>
 #include <ostream>
 #include <stdexcept>
 

--- a/tools/utils/utils.hpp
+++ b/tools/utils/utils.hpp
@@ -1,5 +1,5 @@
-// evmone: Fast Ethereum Virtual Machine implementation
-// Copyright 2018-2019 The EVMC Authors.
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2018-2020 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 #pragma once
 


### PR DESCRIPTION
Move utils.{hpp,cpp} files to new evmc::tool-utils static library.
It is going to be used in unit tests.