### PR TITLE
cmake: Add example end-to-end tests to CTest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,10 +66,6 @@ commands:
           name: "Test"
           command: |
             cmake --build ~/build --target test -- ARGS="-j4 --schedule-random --output-on-failure"
-            # Test statically linked end-to-end example
-            ~/build/examples/evmc-example-static
-            # Test dynamically loaded end-to-end example
-            ~/build/examples/evmc-example ~/build/examples/example_vm/libexample-vm.so
 
 jobs:
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,10 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2018-2019 The EVMC Authors.
+# Copyright 2018-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 add_subdirectory(cmake_package)
 add_subdirectory(compilation)
+add_subdirectory(examples)
 add_subdirectory(tools)
 add_subdirectory(unittests)
 add_subdirectory(vmtester)

--- a/test/examples/CMakeLists.txt
+++ b/test/examples/CMakeLists.txt
@@ -1,0 +1,8 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2020 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+set(PREFIX ${PROJECT_NAME}/examples)
+
+add_test(NAME ${PREFIX}/example-static COMMAND evmc-example-static)
+add_test(NAME ${PREFIX}/example-dynamic-load COMMAND evmc-example $<TARGET_FILE:evmc::example-vm>)


### PR DESCRIPTION
Include EVMC examples tests in CTest.