### PR TITLE
java: statically load JNI library

### DIFF
--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -3,6 +3,18 @@
 # Licensed under the Apache License, Version 2.0.
 
 JAVA_HOME:=$(shell java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | sed 's/\s*java.home = //' | sed 's/\/jre//')
+EXTENSION:="so"
+ifeq ($(OS),Windows_NT)
+    EXTENSION:=dll
+else
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Linux)
+        EXTENSION:=so
+    endif
+    ifeq ($(UNAME_S),Darwin)
+        EXTENSION:=dylib
+    endif
+endif
 
 SOURCE_DIR = $(realpath $(CURDIR)/../..)
 OUT_DIR = $(CURDIR)/c/build
@@ -11,7 +23,7 @@ BUILD_DIR = $(OUT_DIR)/_cmake_build
 lint: gradlew
 	./gradlew --no-daemon clean spotlessCheck
 
-build: gradlew $(OUT_DIR)/lib/libevmc-java.so
+build: gradlew java/src/test/resources/libexample-vm.$(EXTENSION) java/src/main/resources/libevmc-java.$(EXTENSION)
 	mkdir -p ./java/build
 	./gradlew --no-daemon clean spotlessApply build
 
@@ -21,10 +33,20 @@ test: build
 gradlew:
 	gradle --no-daemon setup
 
-$(OUT_DIR)/lib/libevmc-java.so:
+$(OUT_DIR)/lib/libexample-vm.$(EXTENSION): $(OUT_DIR)/lib/libevmc-java.$(EXTENSION)
+
+$(OUT_DIR)/lib/libevmc-java.$(EXTENSION):
 	mkdir -p $(BUILD_DIR)
 	(cd $(BUILD_DIR) && cmake $(SOURCE_DIR) -DCMAKE_INSTALL_PREFIX=$(OUT_DIR) -DEVMC_JAVA=ON -DJAVA_HOME=$(JAVA_HOME) -DEVMC_EXAMPLES=ON)
 	cmake --build $(OUT_DIR)/_cmake_build --target install
+
+java/src/main/resources/libevmc-java.$(EXTENSION): $(OUT_DIR)/lib/libevmc-java.$(EXTENSION)
+	mkdir -p java/src/main/resources
+	cp $(OUT_DIR)/lib/libevmc-java.$(EXTENSION) java/src/main/resources/libevmc-java.$(EXTENSION)
+
+java/src/test/resources/libexample-vm.$(EXTENSION): $(OUT_DIR)/lib/libexample-vm.$(EXTENSION)
+	mkdir -p java/src/test/resources
+	cp $(OUT_DIR)/lib/libexample-vm.$(EXTENSION) java/src/test/resources/libexample-vm.$(EXTENSION)
 
 clean:
 	rm -rf $(OUT_DIR)

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
@@ -3,14 +3,29 @@
 // Licensed under the Apache License, Version 2.0.
 package org.ethereum.evmc;
 
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class EvmcTest {
-  private static final String exampleVmPath =
-      System.getProperty("user.dir") + "/../c/build/lib/libexample-vm.so";
+  private static final String exampleVmPath;
+
+  static {
+    String extension = null;
+    String os = System.getProperty("os.name", "generic").toLowerCase();
+    if (os.contains("mac") || os.contains("darwin")) {
+      extension = "dylib";
+    } else if (os.contains("win")) {
+      extension = "dll";
+    } else {
+      extension = "so";
+    }
+
+    URL exampleVM = EvmcTest.class.getClassLoader().getResource("libexample-vm." + extension);
+    exampleVmPath = exampleVM.getFile();
+  }
 
   @Test
   void testInitCloseDestroy() throws Exception {


### PR DESCRIPTION
This should implement the pattern of storing the shared object in the JAR file, copying it to a temp folder, and loading it from there.