### PR TITLE
C++: Use simpler 3a + b folding in std::hash

### DIFF
--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -833,8 +833,8 @@ struct hash<evmc::address>
         using namespace evmc;
         using namespace fnv;
         return static_cast<size_t>(fnv1a_by64(
-            fnv1a_by64(fnv1a_by64(fnv::offset_basis, load64be(&s.bytes[0])), load64be(&s.bytes[8])),
-            load32be(&s.bytes[16])));
+            fnv1a_by64(fnv1a_by64(fnv::offset_basis, load64le(&s.bytes[0])), load64le(&s.bytes[8])),
+            load32le(&s.bytes[16])));
     }
 };
 
@@ -848,10 +848,10 @@ struct hash<evmc::bytes32>
         using namespace evmc;
         using namespace fnv;
         return static_cast<size_t>(
-            fnv1a_by64(fnv1a_by64(fnv1a_by64(fnv1a_by64(fnv::offset_basis, load64be(&s.bytes[0])),
-                                             load64be(&s.bytes[8])),
-                                  load64be(&s.bytes[16])),
-                       load64be(&s.bytes[24])));
+            fnv1a_by64(fnv1a_by64(fnv1a_by64(fnv1a_by64(fnv::offset_basis, load64le(&s.bytes[0])),
+                                             load64le(&s.bytes[8])),
+                                  load64le(&s.bytes[16])),
+                       load64le(&s.bytes[24])));
     }
 };
 }  // namespace std

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -111,6 +111,8 @@ TEST(cpp, std_hash)
 #pragma warning(disable : 4307 /* integral constant overflow */)
 #pragma warning(disable : 4309 /* 'static_cast': truncation of constant value */)
 
+    using namespace evmc::literals;
+
     static_assert(std::hash<evmc::address>{}({}) == static_cast<size_t>(0xd94d12186c0f2fb7), "");
     static_assert(std::hash<evmc::bytes32>{}({}) == static_cast<size_t>(0x4d25767f9dce13f5), "");
 
@@ -124,6 +126,12 @@ TEST(cpp, std_hash)
     auto eb = evmc::bytes32{};
     std::fill_n(eb.bytes, sizeof(eb), uint8_t{0xee});
     EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
+
+    auto rand_address = 0xaa00bb00cc00dd00ee00ff001100220033004400_address;
+    EXPECT_EQ(std::hash<evmc::address>{}(rand_address), static_cast<size_t>(0x17f74b6894b0f6b7));
+
+    auto rand_bytes32 = 0xbb01bb02bb03bb04bb05bb06bb07bb08bb09bb0abb0bbb0cbb0dbb0ebb0fbb00_bytes32;
+    EXPECT_EQ(std::hash<evmc::bytes32>{}(rand_bytes32), static_cast<size_t>(0x4efee0983bb6c4f5));
 
 #pragma warning(pop)
 }

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -127,11 +127,19 @@ TEST(cpp, std_hash)
     std::fill_n(eb.bytes, sizeof(eb), uint8_t{0xee});
     EXPECT_EQ(std::hash<evmc::bytes32>{}(eb), static_cast<size_t>(0xbb14e5c56b477375));
 
-    auto rand_address = 0xaa00bb00cc00dd00ee00ff001100220033004400_address;
-    EXPECT_EQ(std::hash<evmc::address>{}(rand_address), static_cast<size_t>(0x17f74b6894b0f6b7));
+    const auto rand_address_1 = 0xaa00bb00cc00dd00ee00ff001100220033004400_address;
+    EXPECT_EQ(std::hash<evmc::address>{}(rand_address_1), static_cast<size_t>(0x30022347e325524e));
 
-    auto rand_bytes32 = 0xbb01bb02bb03bb04bb05bb06bb07bb08bb09bb0abb0bbb0cbb0dbb0ebb0fbb00_bytes32;
-    EXPECT_EQ(std::hash<evmc::bytes32>{}(rand_bytes32), static_cast<size_t>(0x4efee0983bb6c4f5));
+    const auto rand_address_2 = 0x00dd00cc00bb00aa0022001100ff00ee00440033_address;
+    EXPECT_EQ(std::hash<evmc::address>{}(rand_address_2), static_cast<size_t>(0x17f74b6894b0f6b7));
+
+    const auto rand_bytes32_1 =
+        0xbb01bb02bb03bb04bb05bb06bb07bb08bb09bb0abb0bbb0cbb0dbb0ebb0fbb00_bytes32;
+    EXPECT_EQ(std::hash<evmc::bytes32>{}(rand_bytes32_1), static_cast<size_t>(0x4f857586d70f2db9));
+
+    const auto rand_bytes32_2 =
+        0x04bb03bb02bb01bb08bb07bb06bb05bb0cbb0bbb0abb09bb00bb0fbb0ebb0dbb_bytes32;
+    EXPECT_EQ(std::hash<evmc::bytes32>{}(rand_bytes32_2), static_cast<size_t>(0x4efee0983bb6c4f5));
 
 #pragma warning(pop)
 }


### PR DESCRIPTION
This replaces the big-endian loads with little-endian loads in hash functions for `evmc::address` and `evmc::bytes32`.
Performance improvements are significant.
```
hash_<evmc::bytes32, hash<evmc::bytes32>>_mean                           -0.2973         -0.2973          2335          1641          2335          1641
hash_<evmc::bytes32, noinline_hash<evmc::bytes32>>_mean                  -0.1559         -0.1559          3045          2571          3045          2571
hash_<evmc::address, hash<evmc::address>>_mean                           -0.4009         -0.4009          1323           793          1323           793
hash_<evmc::address, noinline_hash<evmc::address>>_mean                  -0.2762         -0.2762          1955          1415          1955          1415
```

Originally, I also tried much simpler word folding `fold(a, b): 3*a + b`. These hashes does not look very random any more, and hash of zero is zero. Furthermore, it only improves performance (over little-endian version) for hash functions inlined in a loop, what is probably not the case for hash maps.
```
hash_<evmc::bytes32, hash<evmc::bytes32>>_mean                           -0.1432         -0.1432          1641          1406          1641          1406
hash_<evmc::bytes32, noinline_hash<evmc::bytes32>>_mean                  -0.0006         -0.0006          2571          2569          2571          2569
hash_<evmc::address, hash<evmc::address>>_mean                           -0.1896         -0.1896           793           643           793           643
hash_<evmc::address, noinline_hash<evmc::address>>_mean                  -0.0087         -0.0087          1415          1403          1415          1403
```

We can revisit more optimizations here, but we should build some hashmap performance testing up front (e.g. see https://stackoverflow.com/a/62345875/725174).