### PR TITLE
Testable tool commands

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -153,6 +153,7 @@ jobs:
           command: |
             # Convert to relative paths
             sed -i 's|$(pwd)/||' ~/build/evmc.lcov
+            sudo pip3 install --upgrade --quiet --no-cache-dir codecov
             codecov --file ~/build/evmc.lcov -X gcov
 
 

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -113,34 +113,34 @@ struct bytes32 : evmc_bytes32
 using uint256be = bytes32;
 
 
-/// Loads 64 bits / 8 bytes of data from the given @p bytes array in big-endian order.
-inline constexpr uint64_t load64be(const uint8_t* bytes) noexcept
+/// Loads 64 bits / 8 bytes of data from the given @p data array in big-endian order.
+inline constexpr uint64_t load64be(const uint8_t* data) noexcept
 {
-    return (uint64_t{bytes[0]} << 56) | (uint64_t{bytes[1]} << 48) | (uint64_t{bytes[2]} << 40) |
-           (uint64_t{bytes[3]} << 32) | (uint64_t{bytes[4]} << 24) | (uint64_t{bytes[5]} << 16) |
-           (uint64_t{bytes[6]} << 8) | uint64_t{bytes[7]};
+    return (uint64_t{data[0]} << 56) | (uint64_t{data[1]} << 48) | (uint64_t{data[2]} << 40) |
+           (uint64_t{data[3]} << 32) | (uint64_t{data[4]} << 24) | (uint64_t{data[5]} << 16) |
+           (uint64_t{data[6]} << 8) | uint64_t{data[7]};
 }
 
-/// Loads 64 bits / 8 bytes of data from the given @p bytes array in little-endian order.
-inline constexpr uint64_t load64le(const uint8_t* bytes) noexcept
+/// Loads 64 bits / 8 bytes of data from the given @p data array in little-endian order.
+inline constexpr uint64_t load64le(const uint8_t* data) noexcept
 {
-    return uint64_t{bytes[0]} | (uint64_t{bytes[1]} << 8) | (uint64_t{bytes[2]} << 16) |
-           (uint64_t{bytes[3]} << 24) | (uint64_t{bytes[4]} << 32) | (uint64_t{bytes[5]} << 40) |
-           (uint64_t{bytes[6]} << 48) | (uint64_t{bytes[7]} << 56);
+    return uint64_t{data[0]} | (uint64_t{data[1]} << 8) | (uint64_t{data[2]} << 16) |
+           (uint64_t{data[3]} << 24) | (uint64_t{data[4]} << 32) | (uint64_t{data[5]} << 40) |
+           (uint64_t{data[6]} << 48) | (uint64_t{data[7]} << 56);
 }
 
-/// Loads 32 bits / 4 bytes of data from the given @p bytes array in big-endian order.
-inline constexpr uint32_t load32be(const uint8_t* bytes) noexcept
+/// Loads 32 bits / 4 bytes of data from the given @p data array in big-endian order.
+inline constexpr uint32_t load32be(const uint8_t* data) noexcept
 {
-    return (uint32_t{bytes[0]} << 24) | (uint32_t{bytes[1]} << 16) | (uint32_t{bytes[2]} << 8) |
-           uint32_t{bytes[3]};
+    return (uint32_t{data[0]} << 24) | (uint32_t{data[1]} << 16) | (uint32_t{data[2]} << 8) |
+           uint32_t{data[3]};
 }
 
-/// Loads 32 bits / 4 bytes of data from the given @p bytes array in little-endian order.
-inline constexpr uint32_t load32le(const uint8_t* bytes) noexcept
+/// Loads 32 bits / 4 bytes of data from the given @p data array in little-endian order.
+inline constexpr uint32_t load32le(const uint8_t* data) noexcept
 {
-    return uint32_t{bytes[0]} | (uint32_t{bytes[1]} << 8) | (uint32_t{bytes[2]} << 16) |
-           (uint32_t{bytes[3]} << 24);
+    return uint32_t{data[0]} | (uint32_t{data[1]} << 8) | (uint32_t{data[2]} << 16) |
+           (uint32_t{data[3]} << 24);
 }
 
 namespace fnv

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
     loader_mock.h
     loader_test.cpp
     mocked_host_test.cpp
+    tool_commands_test.cpp
 )
 
 target_link_libraries(
@@ -32,6 +33,7 @@ target_link_libraries(
     evmc::example-precompiles-vm-static
     evmc::instructions
     evmc::evmc_cpp
+    evmc::tool-commands
     GTest::gtest_main
 )
 set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)

--- a/test/unittests/tool_commands_test.cpp
+++ b/test/unittests/tool_commands_test.cpp
@@ -1,0 +1,48 @@
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include "examples/example_vm/example_vm.h"
+#include "tools/commands/commands.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace evmc;
+
+namespace
+{
+std::string out_pattern(const char* rev,
+                        int gas_limit,
+                        const char* status,
+                        int gas_used,
+                        const char* output = nullptr)
+{
+    std::ostringstream s;
+    s << "Executing on " << rev << " with " << gas_limit << " gas limit\n\n"
+      << "Result:   " << status << "\nGas used: " << gas_used << "\n";
+    if (output)
+        s << "Output:   " << output << "\n";
+    return s.str();
+}
+}  // namespace
+
+TEST(tool_commands, run_empty_code)
+{
+    auto vm = evmc::VM{evmc_create_example_vm()};
+    std::ostringstream out;
+
+    const auto exit_code = cmd::run(vm, EVMC_FRONTIER, 1, "", out);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(out.str(), out_pattern("Frontier", 1, "failure", 1));
+}
+
+TEST(tool_commands, run_return_my_address)
+{
+    auto vm = evmc::VM{evmc_create_example_vm()};
+    std::ostringstream out;
+
+    const auto exit_code = cmd::run(vm, EVMC_HOMESTEAD, 200, "30600052596000f3", out);
+    EXPECT_EQ(exit_code, 0);
+    EXPECT_EQ(out.str(), out_pattern("Homestead", 200, "success", 200,
+                                     "0000000000000000000000000000000000000000"));
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
+add_subdirectory(commands)
 add_subdirectory(evmc)
 add_subdirectory(utils)
 add_subdirectory(vmtester)

--- a/tools/commands/CMakeLists.txt
+++ b/tools/commands/CMakeLists.txt
@@ -1,0 +1,9 @@
+# EVMC: Ethereum Client-VM Connector API.
+# Copyright 2020 The EVMC Authors.
+# Licensed under the Apache License, Version 2.0.
+
+add_library(tool-commands commands.hpp run.cpp)
+add_library(evmc::tool-commands ALIAS tool-commands)
+target_compile_features(tool-commands PUBLIC cxx_std_14)
+target_include_directories(tool-commands PUBLIC ${PROJECT_SOURCE_DIR})
+target_link_libraries(tool-commands PRIVATE evmc::tool-utils evmc::mocked_host)

--- a/tools/commands/commands.hpp
+++ b/tools/commands/commands.hpp
@@ -1,0 +1,19 @@
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include <evmc/evmc.hpp>
+#include <iosfwd>
+#include <string>
+
+namespace evmc
+{
+namespace cmd
+{
+int run(evmc::VM& vm,
+        evmc_revision rev,
+        int64_t gas,
+        const std::string& code_hex,
+        std::ostream& out);
+}
+}  // namespace evmc

--- a/tools/commands/run.cpp
+++ b/tools/commands/run.cpp
@@ -1,0 +1,39 @@
+// EVMC: Ethereum Client-VM Connector API.
+// Copyright 2019-2020 The EVMC Authors.
+// Licensed under the Apache License, Version 2.0.
+
+#include "tools/commands/commands.hpp"
+#include "tools/utils/utils.hpp"
+#include <evmc/mocked_host.hpp>
+#include <ostream>
+
+namespace evmc
+{
+namespace cmd
+{
+int run(evmc::VM& vm,
+        evmc_revision rev,
+        int64_t gas,
+        const std::string& code_hex,
+        std::ostream& out)
+{
+    out << "Executing on " << rev << " with " << gas << " gas limit\n";
+
+    const auto code = from_hex(code_hex);
+    evmc_message msg{};
+    msg.gas = gas;
+    MockedHost host;
+
+    const auto result = vm.execute(host, rev, msg, code.data(), code.size());
+
+    const auto gas_used = msg.gas - result.gas_left;
+
+    out << "\nResult:   " << result.status_code << "\nGas used: " << gas_used << "\n";
+
+    if (result.status_code == EVMC_SUCCESS || result.status_code == EVMC_REVERT)
+        out << "Output:   " << hex(result.output_data, result.output_size) << "\n";
+
+    return 0;
+}
+}  // namespace cmd
+}  // namespace evmc

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -12,4 +12,4 @@ set_target_properties(evmc-tool PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set_source_files_properties(main.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
-target_link_libraries(evmc-tool PRIVATE evmc::tool-utils evmc::mocked_host evmc::loader CLI11::CLI11)
+target_link_libraries(evmc-tool PRIVATE evmc::tool-commands evmc::loader CLI11::CLI11)

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -1,11 +1,10 @@
 // EVMC: Ethereum Client-VM Connector API.
-// Copyright 2019 The EVMC Authors.
+// Copyright 2019-2020 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
+#include "tools/commands/commands.hpp"
 #include <CLI/CLI.hpp>
 #include <evmc/loader.h>
-#include <evmc/mocked_host.hpp>
-#include <tools/utils/utils.hpp>
 
 int main(int argc, const char** argv)
 {
@@ -16,15 +15,13 @@ int main(int argc, const char** argv)
 
     std::string vm_config;
     std::string code_hex;
-    evmc_message msg{};
-    msg.gas = 1000000;
+    int64_t gas = 1000000;
     auto rev = EVMC_ISTANBUL;
 
     auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
     run_cmd.add_option("code", code_hex, "Hex-encoded bytecode")->required();
     run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required()->envname("EVMC_VM");
-    run_cmd.add_option("--gas", msg.gas, "Execution gas limit", true)
-        ->check(CLI::Range(0, 1000000000));
+    run_cmd.add_option("--gas", gas, "Execution gas limit", true)->check(CLI::Range(0, 1000000000));
     run_cmd.add_option("--rev", rev, "EVM revision", true);
 
     try
@@ -40,8 +37,6 @@ int main(int argc, const char** argv)
 
         if (run_cmd)
         {
-            const auto code = from_hex(code_hex);
-
             evmc_loader_error_code ec;
             auto vm = VM{evmc_load_and_configure(vm_config.c_str(), &ec)};
             if (ec != EVMC_LOADER_SUCCESS)
@@ -53,21 +48,8 @@ int main(int argc, const char** argv)
                     std::cerr << "Loading error " << ec << "\n";
                 return static_cast<int>(ec);
             }
-
-            MockedHost host;
-
-            std::cout << "Executing on " << rev << " with " << msg.gas << " gas limit\n"
-                      << "in " << vm_config << "\n";
-            const auto result = vm.execute(host, rev, msg, code.data(), code.size());
-
-            const auto gas_used = msg.gas - result.gas_left;
-
-            std::cout << "\nResult:   " << result.status_code << "\nGas used: " << gas_used << "\n";
-
-            if (result.status_code == EVMC_SUCCESS || result.status_code == EVMC_REVERT)
-                std::cout << "Output:   " << hex(result.output_data, result.output_size) << "\n";
-
-            return 0;
+            std::cout << "Config: " << vm_config << "\n";
+            return cmd::run(vm, rev, gas, code_hex, std::cout);
         }
 
         return 0;


### PR DESCRIPTION
This move the implementation of "run" command from the `evmc` tool to separate library. This allows provide unit tests for this command.