### PR TITLE
Add --create option to `evmc run`

### DIFF
--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -33,5 +33,11 @@ add_evmc_tool_test(
     "Result: +success[\r\n]+Gas used: +7[\r\n]+Output: +aabbccdd00000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 
+add_evmc_tool_test(
+    create_return_2
+    "--vm $<TARGET_FILE:evmc::example-vm> run --create 6960026000526001601ff3600052600a6016f3"
+    "Result: +success[\r\n]+Gas used: +6[\r\n]+Output: +02[\r\n]"
+)
+
 get_property(TOOLS_TESTS DIRECTORY PROPERTY TESTS)
 set_tests_properties(${TOOLS_TESTS} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/tools-%p.profraw)

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -2,41 +2,34 @@
 # Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-set(PREFIX ${PROJECT_NAME}/evmc-tool)
+function(add_evmc_tool_test NAME ARGUMENTS EXPECTED_OUTPUT)
+    separate_arguments(ARGUMENTS)
+    add_test(NAME ${PROJECT_NAME}/evmc-tool/${NAME} COMMAND evmc::tool ${ARGUMENTS})
+    set_tests_properties(${PROJECT_NAME}/evmc-tool/${NAME} PROPERTIES PASS_REGULAR_EXPRESSION ${EXPECTED_OUTPUT})
+endfunction()
 
-add_test(
-    NAME ${PREFIX}/example1
-    COMMAND evmc::tool --vm $<TARGET_FILE:evmc::example-vm> run 30600052596000f3 --gas 99
-)
-set_tests_properties(
-    ${PREFIX}/example1 PROPERTIES PASS_REGULAR_EXPRESSION
+
+add_evmc_tool_test(
+    example1
+    "--vm $<TARGET_FILE:evmc::example-vm> run 30600052596000f3 --gas 99"
     "Result: +success[\r\n]+Gas used: +6[\r\n]+Output: +0000000000000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 
-add_test(
-    NAME ${PREFIX}/version
-    COMMAND evmc::tool --version
-)
-set_tests_properties(
-    ${PREFIX}/version PROPERTIES PASS_REGULAR_EXPRESSION
+add_evmc_tool_test(
+    version
+    "--version"
     "EVMC ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::tool>\\)"
 )
 
-add_test(
-    NAME ${PREFIX}/version_vm
-    COMMAND evmc::tool --vm $<TARGET_FILE:evmc::example-vm> --version
-)
-set_tests_properties(
-    ${PREFIX}/version_vm PROPERTIES PASS_REGULAR_EXPRESSION
+add_evmc_tool_test(
+    version_vm
+    "--vm $<TARGET_FILE:evmc::example-vm> --version"
     "example_vm ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::example-vm>\\)[\r\n]EVMC ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::tool>\\)"
 )
 
-add_test(
-    NAME ${PREFIX}/copy_input
-    COMMAND evmc::tool --vm $<TARGET_FILE:evmc::example-vm> run 600035600052596000f3 --input aabbccdd
-)
-set_tests_properties(
-    ${PREFIX}/copy_input PROPERTIES PASS_REGULAR_EXPRESSION
+add_evmc_tool_test(
+    copy_input
+    "--vm $<TARGET_FILE:evmc::example-vm> run 600035600052596000f3 --input aabbccdd"
     "Result: +success[\r\n]+Gas used: +7[\r\n]+Output: +aabbccdd00000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 

--- a/tools/commands/commands.hpp
+++ b/tools/commands/commands.hpp
@@ -15,6 +15,7 @@ int run(evmc::VM& vm,
         int64_t gas,
         const std::string& code_hex,
         const std::string& input_hex,
+        bool create,
         std::ostream& out);
 }
 }  // namespace evmc

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -15,6 +15,7 @@ int main(int argc, const char** argv)
     int64_t gas = 1000000;
     auto rev = EVMC_ISTANBUL;
     std::string input_hex;
+    auto create = false;
 
     CLI::App app{"EVMC tool"};
     const auto& version_flag = *app.add_flag("--version", "Print version information and exit");
@@ -26,6 +27,9 @@ int main(int argc, const char** argv)
     run_cmd.add_option("--gas", gas, "Execution gas limit", true)->check(CLI::Range(0, 1000000000));
     run_cmd.add_option("--rev", rev, "EVM revision", true);
     run_cmd.add_option("--input", input_hex, "Hex-encoded input bytes");
+    run_cmd.add_flag(
+        "--create", create,
+        "Create new contract out of the code and then execute this contract with the input");
 
     try
     {
@@ -67,7 +71,7 @@ int main(int argc, const char** argv)
                 throw CLI::RequiredError{vm_option.get_name()};
 
             std::cout << "Config: " << vm_config << "\n";
-            return cmd::run(vm, rev, gas, code_hex, input_hex, std::cout);
+            return cmd::run(vm, rev, gas, code_hex, input_hex, create, std::cout);
         }
 
         return 0;


### PR DESCRIPTION
```shell=
> bin/evmc run -h
Execute EVM bytecode
Usage: bin/evmc run [OPTIONS] code

Positionals:
  code TEXT REQUIRED          Hex-encoded bytecode

Options:
  -h,--help                   Print this help message and exit
  --gas INT:INT in [0 - 1000000000]=1000000
                              Execution gas limit
  --rev ENUM=7                EVM revision
  --input TEXT                Hex-encoded input bytes
  --create                    Create new contract out of the code and then execute this contract with the input
```