### PR TITLE
tools: Include VM name and version in evmc --version

### DIFF
--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -6,7 +6,7 @@ set(prefix ${PROJECT_NAME}/evmc-run)
 
 add_test(
     NAME ${prefix}/example1
-    COMMAND evmc::tool run --vm $<TARGET_FILE:evmc::example-vm> 30600052596000f3 --gas 99
+    COMMAND evmc::tool --vm $<TARGET_FILE:evmc::example-vm> run 30600052596000f3 --gas 99
 )
 set_tests_properties(
     ${prefix}/example1 PROPERTIES PASS_REGULAR_EXPRESSION

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019-2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-set(prefix ${PROJECT_NAME}/evmc-run)
+set(prefix ${PROJECT_NAME}/evmc-tool)
 
 add_test(
     NAME ${prefix}/example1
@@ -11,6 +11,24 @@ add_test(
 set_tests_properties(
     ${prefix}/example1 PROPERTIES PASS_REGULAR_EXPRESSION
     "Result: +success[\r\n]+Gas used: +6[\r\n]+Output: +0000000000000000000000000000000000000000000000000000000000000000[\r\n]"
+)
+
+add_test(
+    NAME ${prefix}/version
+    COMMAND evmc::tool --version
+)
+set_tests_properties(
+    ${prefix}/version PROPERTIES PASS_REGULAR_EXPRESSION
+    "EVMC ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::tool>\\)"
+)
+
+add_test(
+    NAME ${prefix}/version_vm
+    COMMAND evmc::tool --vm $<TARGET_FILE:evmc::example-vm> --version
+)
+set_tests_properties(
+    ${prefix}/version_vm PROPERTIES PASS_REGULAR_EXPRESSION
+    "example_vm ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::example-vm>\\)[\r\n]EVMC ${PROJECT_VERSION} \\($<TARGET_FILE:evmc::tool>\\)"
 )
 
 get_property(tools_tests DIRECTORY PROPERTY TESTS)

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -10,23 +10,40 @@ int main(int argc, const char** argv)
 {
     using namespace evmc;
 
-    CLI::App app{"EVMC tool"};
-    const auto& version_flag = *app.add_flag("--version", "Print version information");
-
     std::string vm_config;
     std::string code_hex;
     int64_t gas = 1000000;
     auto rev = EVMC_ISTANBUL;
 
+    CLI::App app{"EVMC tool"};
+    const auto& version_flag = *app.add_flag("--version", "Print version information");
+    const auto& vm_option =
+        *app.add_option("--vm", vm_config, "EVMC VM module")->envname("EVMC_VM");
+
     auto& run_cmd = *app.add_subcommand("run", "Execute EVM bytecode");
     run_cmd.add_option("code", code_hex, "Hex-encoded bytecode")->required();
-    run_cmd.add_option("--vm", vm_config, "EVMC VM module")->required()->envname("EVMC_VM");
     run_cmd.add_option("--gas", gas, "Execution gas limit", true)->check(CLI::Range(0, 1000000000));
     run_cmd.add_option("--rev", rev, "EVM revision", true);
 
     try
     {
         app.parse(argc, argv);
+
+        evmc::VM vm;
+        if (vm_option.count() != 0)
+        {
+            evmc_loader_error_code ec;
+            vm = VM{evmc_load_and_configure(vm_config.c_str(), &ec)};
+            if (ec != EVMC_LOADER_SUCCESS)
+            {
+                const auto error = evmc_last_error_msg();
+                if (error != nullptr)
+                    std::cerr << error << "\n";
+                else
+                    std::cerr << "Loading error " << ec << "\n";
+                return static_cast<int>(ec);
+            }
+        }
 
         // Handle the --version flag first and exit when present.
         if (version_flag)
@@ -37,17 +54,10 @@ int main(int argc, const char** argv)
 
         if (run_cmd)
         {
-            evmc_loader_error_code ec;
-            auto vm = VM{evmc_load_and_configure(vm_config.c_str(), &ec)};
-            if (ec != EVMC_LOADER_SUCCESS)
-            {
-                const auto error = evmc_last_error_msg();
-                if (error != nullptr)
-                    std::cerr << error << "\n";
-                else
-                    std::cerr << "Loading error " << ec << "\n";
-                return static_cast<int>(ec);
-            }
+            // For run command the --vm is required.
+            if (vm_option.count() == 0)
+                throw CLI::RequiredError{vm_option.get_name()};
+
             std::cout << "Config: " << vm_config << "\n";
             return cmd::run(vm, rev, gas, code_hex, std::cout);
         }

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char** argv)
     auto rev = EVMC_ISTANBUL;
 
     CLI::App app{"EVMC tool"};
-    const auto& version_flag = *app.add_flag("--version", "Print version information");
+    const auto& version_flag = *app.add_flag("--version", "Print version information and exit");
     const auto& vm_option =
         *app.add_option("--vm", vm_config, "EVMC VM module")->envname("EVMC_VM");
 
@@ -48,7 +48,13 @@ int main(int argc, const char** argv)
         // Handle the --version flag first and exit when present.
         if (version_flag)
         {
-            std::cout << "EVMC tool " PROJECT_VERSION "\n";
+            if (vm)
+                std::cout << vm.name() << " " << vm.version() << " (" << vm_config << ")\n";
+
+            std::cout << "EVMC " PROJECT_VERSION;
+            if (argc >= 1)
+                std::cout << " (" << argv[0] << ")";
+            std::cout << "\n";
             return 0;
         }
 


### PR DESCRIPTION
```
> bin/evmc --version --vm ~/Projects/ethereum/evmone/build/debug/lib/libevmone.so
evmone 0.6.0-dev (/home/chfast/Projects/ethereum/evmone/build/debug/lib/libevmone.so)
EVMC 7.5.0-alpha.0 (bin/evmc)
```
