### PR TITLE
rust: remove obsolete bindgen commands

### DIFF
--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -11,11 +11,7 @@ use std::path::PathBuf;
 fn gen_bindings() {
     let bindings = bindgen::Builder::default()
         .header("evmc.h")
-        // See https://github.com/rust-lang-nursery/rust-bindgen/issues/947
-        .trust_clang_mangling(false)
         .generate_comments(true)
-        // https://github.com/rust-lang-nursery/rust-bindgen/issues/947#issuecomment-327100002
-        .layout_tests(false)
         // do not generate an empty enum for EVMC_ABI_VERSION
         .constified_enum("")
         // generate Rust enums for each evmc enum


### PR DESCRIPTION
The referred problems were fixed.