### PR TITLE
Make tool-commands lib STATIC similar to tool-utils

### DIFF
--- a/tools/commands/CMakeLists.txt
+++ b/tools/commands/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2020 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
-add_library(tool-commands commands.hpp run.cpp)
+add_library(tool-commands STATIC commands.hpp run.cpp)
 add_library(evmc::tool-commands ALIAS tool-commands)
 target_compile_features(tool-commands PUBLIC cxx_std_14)
 target_include_directories(tool-commands PUBLIC ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Otherwise evmone build fails on Windows: https://ci.appveyor.com/project/chfast/evmone/builds/37856416