### PR TITLE
java: do not abort, but throw an exception in all cases in EvmcVm.create()

### DIFF
--- a/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcLoaderException.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcLoaderException.java
@@ -3,8 +3,13 @@
 // Licensed under the Apache License, Version 2.0.
 package org.ethereum.evmc;
 
+/** Exception thrown when the EVMC binding or VM fails to load. */
 public class EvmcLoaderException extends Exception {
   public EvmcLoaderException(String message) {
     super(message);
+  }
+
+  public EvmcLoaderException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
@@ -28,8 +28,7 @@ public final class EvmcVm implements AutoCloseable {
         System.load(System.getProperty("user.dir") + "/../c/build/lib/libevmc-java.so");
         EvmcVm.isEvmcLibraryLoaded = true;
       } catch (UnsatisfiedLinkError e) {
-        System.err.println("Native code library failed to load.\n" + e);
-        System.exit(1);
+        throw new EvmcLoaderException("EVMC JNI binding library failed to load", e);
       }
     }
     if (Objects.isNull(evmcVm)) {


### PR DESCRIPTION
Pulled out of #555.

#555 will ultimate replace the code in `create()`, but nevertheless this seems to be a nice intermediate step we can merge now, while #555 could take a bit of work 😬 