### PR TITLE
Add EVMC_LONDON revision

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -147,6 +147,8 @@ const (
 	Constantinople   Revision = C.EVMC_CONSTANTINOPLE
 	Petersburg       Revision = C.EVMC_PETERSBURG
 	Istanbul         Revision = C.EVMC_ISTANBUL
+	Berlin           Revision = C.EVMC_BERLIN
+	London           Revision = C.EVMC_LONDON
 )
 
 type VM struct {

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -813,19 +813,26 @@ enum evmc_revision
     /**
      * The Istanbul revision.
      *
-     * The spec draft: https://eips.ethereum.org/EIPS/eip-1679.
+     * https://eips.ethereum.org/EIPS/eip-1679
      */
     EVMC_ISTANBUL = 7,
 
     /**
      * The Berlin revision.
      *
-     * The spec draft: https://eips.ethereum.org/EIPS/eip-2070.
+     * https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md
      */
     EVMC_BERLIN = 8,
 
+    /**
+     * The London revision.
+     *
+     * https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
+     */
+    EVMC_LONDON = 9,
+
     /** The maximum EVM revision supported. */
-    EVMC_MAX_REVISION = EVMC_BERLIN
+    EVMC_MAX_REVISION = EVMC_LONDON
 };
 
 

--- a/lib/instructions/instruction_metrics.c
+++ b/lib/instructions/instruction_metrics.c
@@ -1849,6 +1849,7 @@ const struct evmc_instruction_metrics* evmc_get_instruction_metrics_table(
 {
     switch (revision)
     {
+    case EVMC_LONDON:
     case EVMC_BERLIN:
         return berlin_metrics;
     case EVMC_ISTANBUL:

--- a/lib/instructions/instruction_names.c
+++ b/lib/instructions/instruction_names.c
@@ -1304,8 +1304,9 @@ const char* const* evmc_get_instruction_names_table(enum evmc_revision revision)
 {
     switch (revision)
     {
-    case EVMC_ISTANBUL:
+    case EVMC_LONDON:
     case EVMC_BERLIN:
+    case EVMC_ISTANBUL:
         return istanbul_names;
     case EVMC_PETERSBURG:
     case EVMC_CONSTANTINOPLE:

--- a/test/unittests/instructions_test.cpp
+++ b/test/unittests/instructions_test.cpp
@@ -327,3 +327,17 @@ TEST(instructions, berlin_hard_fork)
     EXPECT_EQ(b[OP_STATICCALL].gas_cost, 100);
     EXPECT_EQ(b[OP_SLOAD].gas_cost, 100);
 }
+
+TEST(instructions, london_hard_fork)
+{
+    const auto l = evmc_get_instruction_metrics_table(EVMC_LONDON);
+    const auto b = evmc_get_instruction_metrics_table(EVMC_BERLIN);
+    const auto ln = evmc_get_instruction_names_table(EVMC_LONDON);
+    const auto bn = evmc_get_instruction_names_table(EVMC_BERLIN);
+
+    for (int op{OP_STOP}; op <= OP_SELFDESTRUCT; ++op)
+    {
+        EXPECT_EQ(l[op], b[op]) << op;
+        EXPECT_STREQ(ln[op], bn[op]) << op;
+    }
+}

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char** argv)
     std::string vm_config;
     std::string code_arg;
     int64_t gas = 1000000;
-    auto rev = EVMC_ISTANBUL;
+    auto rev = EVMC_BERLIN;
     std::string input_arg;
     auto create = false;
 

--- a/tools/utils/utils.cpp
+++ b/tools/utils/utils.cpp
@@ -114,6 +114,9 @@ std::ostream& operator<<(std::ostream& os, evmc_revision revision)
     case EVMC_BERLIN:
         s = "Berlin";
         break;
+    case EVMC_LONDON:
+        s = "London";
+        break;
     default:
         throw std::invalid_argument{"invalid EVM revision: " + std::to_string(revision)};
     }


### PR DESCRIPTION
Add `evmc_revision` value for the upcoming [London fork](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md).