### PR TITLE
cmake: Output executables to top-level /bin dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ project(evmc)
 set(PROJECT_VERSION 8.1.0-alpha.0)
 
 include(GNUInstallDirs)  # Must be included after any language is enabled.
+if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    # By default put every executable in top-level /bin dir.
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+endif()
+
 
 cable_configure_compiler(NO_STACK_PROTECTION)
 if(CABLE_COMPILER_GNULIKE)

--- a/circle.yml
+++ b/circle.yml
@@ -72,7 +72,7 @@ commands:
           root: ~/build
           paths:
             - bin/evmc-vmtester
-            - examples/evmc-example
+            - bin/evmc-example
 
   test:
     steps:
@@ -151,10 +151,10 @@ jobs:
             find -name '*.profraw'
             llvm-profdata merge *.profraw -o evmc.profdata
             llvm-cov report -instr-profile evmc.profdata \
-              -object test/evmc-unittests \
+              -object bin/evmc-unittests \
               -object bin/evmc-vmtester
             llvm-cov export -instr-profile evmc.profdata -format=lcov > evmc.lcov \
-              -object test/evmc-unittests \
+              -object bin/evmc-unittests \
               -object bin/evmc \
               -object bin/evmc-vmtester
             genhtml evmc.lcov -o coverage -t EVMC
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Test with evmc-example
           command: |
-            ~/build/examples/evmc-example target/debug/libexamplerustvm.so
+            ~/build/bin/evmc-example target/debug/libexamplerustvm.so
       - run:
           name: Package evmc-sys
           # NOTE: can not be run for evmc-vm and evmc-declare due to version dependencies
@@ -376,7 +376,7 @@ jobs:
       - run:
           name: Test with evmc-example
           command: |
-            ~/build/examples/evmc-example target/x86_64-unknown-linux-gnu/debug/libexamplerustvm.so
+            ~/build/bin/evmc-example target/x86_64-unknown-linux-gnu/debug/libexamplerustvm.so
 
 workflows:
   version: 2

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -39,7 +39,6 @@ target_link_libraries(
     evmc::hex
     GTest::gtest_main
 )
-set_target_properties(evmc-unittests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ..)
 
 gtest_add_tests(TARGET evmc-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/ TEST_LIST unittests)
 

--- a/tools/evmc/CMakeLists.txt
+++ b/tools/evmc/CMakeLists.txt
@@ -7,9 +7,7 @@ find_package(CLI11 REQUIRED)
 
 add_executable(evmc-tool main.cpp)
 add_executable(evmc::tool ALIAS evmc-tool)
-set_target_properties(evmc-tool PROPERTIES
-    OUTPUT_NAME evmc
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set_target_properties(evmc-tool PROPERTIES OUTPUT_NAME evmc)
 set_source_files_properties(main.cpp PROPERTIES
     COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 target_link_libraries(evmc-tool PRIVATE evmc::tool-commands evmc::loader CLI11::CLI11)

--- a/tools/vmtester/CMakeLists.txt
+++ b/tools/vmtester/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(GTest CONFIG REQUIRED)
 set_target_properties(GTest::gtest PROPERTIES INTERFACE_COMPILE_DEFINITIONS GTEST_HAS_TR1_TUPLE=0)
 
 add_executable(evmc-vmtester vmtester.hpp vmtester.cpp tests.cpp)
-set_target_properties(evmc-vmtester PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
 target_link_libraries(evmc-vmtester PRIVATE evmc::loader evmc::mocked_host GTest::gtest)
 set_source_files_properties(vmtester.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 add_executable(evmc::evmc-vmtester ALIAS evmc-vmtester)


### PR DESCRIPTION
This outputs all EVMC executables in top-level /bin build dir. So for parent projects like evmone e.g. `evmc` will be located in `build/bin/evmc` (`build/evmc/bin/evmc` previously).

The output dir can be changes with standard `-DCMAKE_RUNTIME_OUTPUT_DIRECTORY`.

evmone check: https://github.com/ethereum/evmone/pull/330.