### PR TITLE
Add EVMC_LATEST_STABLE_REVISON

### DIFF
--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -840,7 +840,14 @@ enum evmc_revision
     EVMC_SHANGHAI = 10,
 
     /** The maximum EVM revision supported. */
-    EVMC_MAX_REVISION = EVMC_SHANGHAI
+    EVMC_MAX_REVISION = EVMC_SHANGHAI,
+
+    /**
+     * The latest known EVM revision with finalized specification.
+     *
+     * This is handy for EVM tools to always use the latest revision available.
+     */
+    EVMC_LATEST_STABLE_REVISION = EVMC_LONDON
 };
 
 

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -34,6 +34,12 @@ add_evmc_tool_test(
 )
 
 add_evmc_tool_test(
+    default_revision
+    "--vm $<TARGET_FILE:evmc::example-vm> run 00"
+    "Executing on London"
+)
+
+add_evmc_tool_test(
     create_return_2
     "--vm $<TARGET_FILE:evmc::example-vm> run --create 6960026000526001601ff3600052600a6016f3"
     "Result: +success[\r\n]+Gas used: +6[\r\n]+Output: +02[\r\n]"

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char** argv)
     std::string vm_config;
     std::string code_arg;
     int64_t gas = 1000000;
-    auto rev = EVMC_BERLIN;
+    auto rev = EVMC_LATEST_STABLE_REVISION;
     std::string input_arg;
     auto create = false;
     auto bench = false;


### PR DESCRIPTION
```c
    /**
     * The latest known EVM revision with finalized specification.
     *
     * This is handy for EVM tools to always use the latest revision available.
     */
    EVMC_LATEST_STABLE_REVISION = EVMC_LONDON
```