### PR TITLE
go: Add missing Shanghai revision constant

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -139,16 +139,18 @@ const (
 type Revision int32
 
 const (
-	Frontier         Revision = C.EVMC_FRONTIER
-	Homestead        Revision = C.EVMC_HOMESTEAD
-	TangerineWhistle Revision = C.EVMC_TANGERINE_WHISTLE
-	SpuriousDragon   Revision = C.EVMC_SPURIOUS_DRAGON
-	Byzantium        Revision = C.EVMC_BYZANTIUM
-	Constantinople   Revision = C.EVMC_CONSTANTINOPLE
-	Petersburg       Revision = C.EVMC_PETERSBURG
-	Istanbul         Revision = C.EVMC_ISTANBUL
-	Berlin           Revision = C.EVMC_BERLIN
-	London           Revision = C.EVMC_LONDON
+	Frontier             Revision = C.EVMC_FRONTIER
+	Homestead            Revision = C.EVMC_HOMESTEAD
+	TangerineWhistle     Revision = C.EVMC_TANGERINE_WHISTLE
+	SpuriousDragon       Revision = C.EVMC_SPURIOUS_DRAGON
+	Byzantium            Revision = C.EVMC_BYZANTIUM
+	Constantinople       Revision = C.EVMC_CONSTANTINOPLE
+	Petersburg           Revision = C.EVMC_PETERSBURG
+	Istanbul             Revision = C.EVMC_ISTANBUL
+	Berlin               Revision = C.EVMC_BERLIN
+	London               Revision = C.EVMC_LONDON
+	MaxRevision          Revision = C.EVMC_MAX_REVISION
+	LatestStableRevision Revision = C.EVMC_LATEST_STABLE_REVISION
 )
 
 type VM struct {

--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -149,6 +149,7 @@ const (
 	Istanbul             Revision = C.EVMC_ISTANBUL
 	Berlin               Revision = C.EVMC_BERLIN
 	London               Revision = C.EVMC_LONDON
+	Shanghai             Revision = C.EVMC_SHANGHAI
 	MaxRevision          Revision = C.EVMC_MAX_REVISION
 	LatestStableRevision Revision = C.EVMC_LATEST_STABLE_REVISION
 )

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -59,3 +59,12 @@ func TestExecuteEmptyCode(t *testing.T) {
 		t.Errorf("execution returned unexpected error: %v", err)
 	}
 }
+
+func TestRevision(t *testing.T) {
+	if MaxRevision != London {
+		t.Errorf("missing constant for revision %d", MaxRevision)
+	}
+	if LatestStableRevision != London {
+		t.Errorf("wrong latest stable revision %d", LatestStableRevision)
+	}
+}

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -61,7 +61,7 @@ func TestExecuteEmptyCode(t *testing.T) {
 }
 
 func TestRevision(t *testing.T) {
-	if MaxRevision != London {
+	if MaxRevision != Shanghai {
 		t.Errorf("missing constant for revision %d", MaxRevision)
 	}
 	if LatestStableRevision != London {


### PR DESCRIPTION
Added a test that fails in case of `C.EVMC_MAX_REVISION` is increased as a remainder to add new Revision constants to Go.
> evmc_test.go:65: missing constant for revision 10

The missing London Revision is added.