### PR TITLE
Add code_address to evmc_message

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -43,6 +43,7 @@ static struct evmc_result execute_wrapper(struct evmc_vm* vm,
 		input_size,
 		*value,
 		{{0}}, // create2_salt: not required for execution
+		{{0}}, // code_address: not required for execution
 	};
 
 	struct evmc_host_context* context = (struct evmc_host_context*)context_index;

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -93,7 +93,7 @@ type HostContext interface {
 	EmitLog(addr Address, topics []Hash, data []byte)
 	Call(kind CallKind,
 		destination Address, sender Address, value Hash, input []byte, gas int64, depth int,
-		static bool, salt Hash) (output []byte, gasLeft int64, createAddr Address, err error)
+		static bool, salt Hash, codeAddress Address) (output []byte, gasLeft int64, createAddr Address, err error)
 	AccessAccount(addr Address) AccessStatus
 	AccessStorage(addr Address, key Hash) AccessStatus
 }
@@ -208,7 +208,8 @@ func call(pCtx unsafe.Pointer, msg *C.struct_evmc_message) C.struct_evmc_result 
 
 	kind := CallKind(msg.kind)
 	output, gasLeft, createAddr, err := ctx.Call(kind, goAddress(msg.destination), goAddress(msg.sender), goHash(msg.value),
-		goByteSlice(msg.input_data, msg.input_size), int64(msg.gas), int(msg.depth), msg.flags != 0, goHash(msg.create2_salt))
+		goByteSlice(msg.input_data, msg.input_size), int64(msg.gas), int(msg.depth), msg.flags != 0, goHash(msg.create2_salt),
+		goAddress(msg.code_address))
 
 	statusCode := C.enum_evmc_status_code(0)
 	if err != nil {

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -57,7 +57,7 @@ func (host *testHostContext) EmitLog(addr Address, topics []Hash, data []byte) {
 
 func (host *testHostContext) Call(kind CallKind,
 	destination Address, sender Address, value Hash, input []byte, gas int64, depth int,
-	static bool, salt Hash) (output []byte, gasLeft int64, createAddr Address, err error) {
+	static bool, salt Hash, codeAddress Address) (output []byte, gasLeft int64, createAddr Address, err error) {
 	output = []byte("output from testHostContext.Call()")
 	return output, gas, Address{}, nil
 }

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/TestMessage.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/TestMessage.java
@@ -19,6 +19,7 @@ public class TestMessage {
   long inputSize;
   char[] value;
   byte[] createSalt;
+  byte[] codeAddress;
 
   public TestMessage(
       int kind,
@@ -38,6 +39,7 @@ public class TestMessage {
     this.inputSize = (long) inputData.length;
     this.value = value;
     this.createSalt = new byte[32];
+    this.codeAddress = new byte[20];
   }
 
   public TestMessage(ByteBuffer msg) {
@@ -56,11 +58,12 @@ public class TestMessage {
     tmpbuf = msg.get(new byte[32]);
     this.value = StandardCharsets.ISO_8859_1.decode(tmpbuf).array();
     this.createSalt = msg.get(new byte[32]).array();
+    this.codeAddress = msg.get(new byte[20]).array();
   }
 
   public ByteBuffer toByteBuffer() {
 
-    return ByteBuffer.allocateDirect(152)
+    return ByteBuffer.allocateDirect(172)
         .order(ByteOrder.nativeOrder())
         .putInt(kind) // 4
         .putInt(flags) // 4
@@ -72,6 +75,7 @@ public class TestMessage {
         .put(StandardCharsets.ISO_8859_1.encode(CharBuffer.wrap(inputData))) // 8
         .putLong(inputSize) // 8
         .put(StandardCharsets.ISO_8859_1.encode(CharBuffer.wrap(value))) // 32
-        .put(createSalt); // 32
+        .put(createSalt) // 32
+        .put(codeAddress); // 20
   }
 }

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -122,6 +122,7 @@ mod tests {
             input_size: 0,
             value: ::evmc_sys::evmc_uint256be::default(),
             create2_salt: ::evmc_sys::evmc_bytes32::default(),
+            code_address: ::evmc_sys::evmc_address::default(),
         };
         let message: ExecutionMessage = (&message).into();
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -109,7 +109,7 @@ struct evmc_message
     /** The amount of gas for message execution. */
     int64_t gas;
 
-    /** The destination of the message. */
+    /** The destination (recipient) of the message. */
     evmc_address destination;
 
     /** The sender of the message. */
@@ -141,6 +141,18 @@ struct evmc_message
      * Ignored in evmc_execute_fn().
      */
     evmc_bytes32 create2_salt;
+
+    /**
+     * The address of the code to be executed.
+     *
+     * May be different from the evmc_message::destination (recipient) in case of
+     * ::EVMC_CALLCODE or ::EVMC_DELEGATECALL.
+     * See Section 8 "Message Call" of the Yellow Paper for detail.
+     *
+     * Not required when invoking evmc_execute_fn(), only when invoking evmc_call_fn().
+     * Ignored if kind is ::EVMC_CREATE or ::EVMC_CREATE2.
+     */
+    evmc_address code_address;
 };
 
 

--- a/tools/vmtester/tests.cpp
+++ b/tools/vmtester/tests.cpp
@@ -87,9 +87,17 @@ TEST_F(evmc_vm_test, execute_call)
 TEST_F(evmc_vm_test, execute_create)
 {
     evmc::MockedHost mockedHost;
-    evmc_message msg{
-        EVMC_CREATE,   0, 0, 65536, evmc_address{}, evmc_address{}, nullptr, 0, evmc_uint256be{},
-        evmc_bytes32{}};
+    evmc_message msg{EVMC_CREATE,
+                     0,
+                     0,
+                     65536,
+                     evmc_address{},
+                     evmc_address{},
+                     nullptr,
+                     0,
+                     evmc_uint256be{},
+                     evmc_bytes32{},
+                     evmc_address{}};
     std::array<uint8_t, 2> code = {{0xfe, 0x00}};
 
     evmc_result result =
@@ -170,9 +178,17 @@ TEST_F(evmc_vm_test, precompile_test)
         destination.bytes[18] = static_cast<uint8_t>(i >> 8);
         destination.bytes[19] = static_cast<uint8_t>(i & 0xff);
 
-        evmc_message msg{
-            EVMC_CALL,     0, 0, 65536, destination, evmc_address{}, nullptr, 0, evmc_uint256be{},
-            evmc_bytes32{}};
+        evmc_message msg{EVMC_CALL,
+                         0,
+                         0,
+                         65536,
+                         destination,
+                         evmc_address{},
+                         nullptr,
+                         0,
+                         evmc_uint256be{},
+                         evmc_bytes32{},
+                         evmc_address{}};
 
         evmc_result result = vm->execute(vm, nullptr, nullptr, EVMC_MAX_REVISION, &msg, nullptr, 0);
 


### PR DESCRIPTION
Without code address `evmc_message` is not enough to implement `evmc_call_fn` for the DELEGATECALL case. For more detail please see https://github.com/torquem-ch/silkworm/pull/286.

**_Warning:_ This is an API breaking change and requires a major version bump!**

Related PRs: https://github.com/ethereum/evmone/pull/360 and https://github.com/torquem-ch/silkworm/pull/288.
