### PR TITLE
go: create2_salt is not required for execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [10.0.0] — unreleased
 
+### Changed
+
+- Go: The `create2Salt` parameter has been removed from the `VM.Execute()`.
+  [#612](https://github.com/ethereum/evmc/pull/612)
+
 ## [9.0.0] — 2021-06-30
 
 ### Added

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -47,7 +47,7 @@ func TestExecuteEmptyCode(t *testing.T) {
 
 	addr := Address{}
 	h := Hash{}
-	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil, h)
+	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
 
 	if bytes.Compare(output, []byte("")) != 0 {
 		t.Errorf("execution unexpected output: %x", output)

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -80,7 +80,7 @@ func TestGetBlockNumberFromTxContext(t *testing.T) {
 	host := &testHostContext{}
 	addr := Address{}
 	h := Hash{}
-	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
+	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
 
 	if len(output) != 32 {
 		t.Errorf("unexpected output size: %d", len(output))
@@ -109,7 +109,7 @@ func TestCall(t *testing.T) {
 	host := &testHostContext{}
 	addr := Address{}
 	h := Hash{}
-	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code, h)
+	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
 
 	if len(output) != 34 {
 		t.Errorf("execution unexpected output length: %d", len(output))

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -137,7 +137,8 @@ struct evmc_message
     /**
      * The optional value used in new contract address construction.
      *
-     * Ignored unless kind is EVMC_CREATE2.
+     * Needed only for a Host to calculate created address when kind is ::EVMC_CREATE2.
+     * Ignored in evmc_execute_fn().
      */
     evmc_bytes32 create2_salt;
 };


### PR DESCRIPTION
Pulled from #611.