### PR TITLE
Clarify evmc_message::code_address usage

### DIFF
--- a/examples/example_precompiles_vm/example_precompiles_vm.cpp
+++ b/examples/example_precompiles_vm/example_precompiles_vm.cpp
@@ -57,12 +57,12 @@ static evmc_result execute(evmc_vm*,
 {
     // The EIP-1352 (https://eips.ethereum.org/EIPS/eip-1352) defines
     // the range 0 - 0xffff (2 bytes) of addresses reserved for precompiled contracts.
-    // Check if the destination address is within the reserved range.
+    // Check if the code address is within the reserved range.
 
     constexpr auto prefix_size = sizeof(evmc_address) - 2;
-    const auto& dst = msg->destination;
+    const auto& addr = msg->code_address;
     // Check if the address prefix is all zeros.
-    if (std::any_of(&dst.bytes[0], &dst.bytes[prefix_size], [](uint8_t x) { return x != 0; }))
+    if (std::any_of(&addr.bytes[0], &addr.bytes[prefix_size], [](uint8_t x) { return x != 0; }))
     {
         // If not, reject the execution request.
         auto result = evmc_result{};
@@ -70,8 +70,8 @@ static evmc_result execute(evmc_vm*,
         return result;
     }
 
-    // Extract the precompiled contract id from last 2 bytes of the destination address.
-    const auto id = (dst.bytes[prefix_size] << 8) | dst.bytes[prefix_size + 1];
+    // Extract the precompiled contract id from last 2 bytes of the code address.
+    const auto id = (addr.bytes[prefix_size] << 8) | addr.bytes[prefix_size + 1];
     switch (id)
     {
     case 0x0001:  // ECDSARECOVER

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -563,7 +563,7 @@ TEST(cpp, vm_execute_precompiles)
     constexpr std::array<uint8_t, 3> input{{1, 2, 3}};
 
     evmc_message msg{};
-    msg.destination.bytes[19] = 4;  // Call Identify precompile at address 0x4.
+    msg.code_address.bytes[19] = 4;  // Call Identify precompile at address 0x4.
     msg.input_data = input.data();
     msg.input_size = input.size();
     msg.gas = 18;

--- a/tools/vmtester/tests.cpp
+++ b/tools/vmtester/tests.cpp
@@ -174,21 +174,21 @@ TEST_F(evmc_vm_test, precompile_test)
     // Iterate every address (as per EIP-1352)
     for (size_t i = 0; i < 0xffff; i++)
     {
-        auto destination = evmc_address{};
-        destination.bytes[18] = static_cast<uint8_t>(i >> 8);
-        destination.bytes[19] = static_cast<uint8_t>(i & 0xff);
+        auto addr = evmc_address{};
+        addr.bytes[18] = static_cast<uint8_t>(i >> 8);
+        addr.bytes[19] = static_cast<uint8_t>(i & 0xff);
 
         evmc_message msg{EVMC_CALL,
                          0,
                          0,
                          65536,
-                         destination,
+                         evmc_address{},
                          evmc_address{},
                          nullptr,
                          0,
                          evmc_uint256be{},
                          evmc_bytes32{},
-                         evmc_address{}};
+                         addr};
 
         evmc_result result = vm->execute(vm, nullptr, nullptr, EVMC_MAX_REVISION, &msg, nullptr, 0);
 


### PR DESCRIPTION
- Clarifies the documentation around `evmc_message::code_address` and other `evmc_message` fields.
- Fixes the usage of `code_address` vs `destination` in the "precompiles vm" example.
- Resolves the issue reported in https://github.com/ethereum/evmc/pull/611#discussion_r702855921.