### PR TITLE
Split block and tx context, use out parameter

### DIFF
--- a/examples/example_vm/example_vm.cpp
+++ b/examples/example_vm/example_vm.cpp
@@ -224,8 +224,9 @@ evmc_result execute(evmc_vm* instance,
 
         case OP_NUMBER:
         {
-            evmc_uint256be value =
-                to_uint256(static_cast<uint32_t>(host->get_tx_context(context).block_number));
+            evmc_tx_context tx = {};
+            host->get_tx_context(&tx, context);
+            evmc_uint256be value = to_uint256(static_cast<uint32_t>(tx.block_number));
             stack.push(value);
             break;
         }

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -214,13 +214,13 @@ struct evmc_host_context;
 /**
  * Get transaction context callback function.
  *
- *  This callback function is used by an EVM to retrieve the transaction and
- *  block context.
+ * This callback function is used by an EVM to retrieve the transaction and block context.
  *
- *  @param      context  The pointer to the Host execution context.
- *  @return              The transaction context.
+ * @param[out] tx_context  The pointer to the transaction context struct to be filled.
+ * @param      host        The pointer to the Host execution context.
  */
-typedef struct evmc_tx_context (*evmc_get_tx_context_fn)(struct evmc_host_context* context);
+typedef void (*evmc_get_tx_context_fn)(struct evmc_tx_context* tx_context,
+                                       struct evmc_host_context* host);
 
 /**
  * Get block hash callback function.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -571,7 +571,7 @@ public:
     evmc_tx_context get_tx_context() const noexcept final
     {
         if (tx_context.block_timestamp == 0)
-            tx_context = host->get_tx_context(context);
+            host->get_tx_context(&tx_context, context);
         return tx_context;
     }
 
@@ -819,9 +819,9 @@ inline evmc_result call(evmc_host_context* h, const evmc_message* msg) noexcept
     return Host::from_context(h)->call(*msg).release_raw();
 }
 
-inline evmc_tx_context get_tx_context(evmc_host_context* h) noexcept
+inline void get_tx_context(evmc_tx_context* tx, evmc_host_context* h) noexcept
 {
-    return Host::from_context(h)->get_tx_context();
+    *tx = Host::from_context(h)->get_tx_context();
 }
 
 inline evmc_bytes32 get_block_hash(evmc_host_context* h, int64_t block_number) noexcept


### PR DESCRIPTION
This split transaction and block context into separate structs. They have different lifetimes so the Host can keep the same block context while processing multiple transactions.

We also return these by out-parameter because otherwise additional copy is needed in VM.