### PR TITLE
C++: Do not cache tx context in HostContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning].
 - The `evmc_message::destination` field has been renamed to `evmc_message::recipient`
   to clarify its purpose and match the naming from the Yellow Paper.
   [#616](https://github.com/ethereum/evmc/pull/616)
+- C++: The `HostContext` does not cache transaction context (`evmc_tx_context`) anymore.
+  [#631](https://github.com/ethereum/evmc/pull/631)
 - Go: The `create2Salt` parameter has been removed from the `VM.Execute()`.
   [#612](https://github.com/ethereum/evmc/pull/612)
 - Code quality improvements.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -499,7 +499,6 @@ class HostContext : public HostInterface
 {
     const evmc_host_interface* host = nullptr;
     evmc_host_context* context = nullptr;
-    mutable evmc_tx_context tx_context = {};
 
 public:
     /// Default constructor for null Host context.
@@ -563,17 +562,7 @@ public:
     }
 
     /// @copydoc HostInterface::get_tx_context()
-    ///
-    /// The implementation caches the received transaction context
-    /// by assuming that the block timestamp should never be zero.
-    ///
-    /// @return The cached transaction context.
-    evmc_tx_context get_tx_context() const noexcept final
-    {
-        if (tx_context.block_timestamp == 0)
-            tx_context = host->get_tx_context(context);
-        return tx_context;
-    }
+    evmc_tx_context get_tx_context() const noexcept final { return host->get_tx_context(context); }
 
     bytes32 get_block_hash(int64_t number) const noexcept final
     {


### PR DESCRIPTION
The C++ API for HostContext was caching the tx context. The caching seems good idea, but the EVM might want to do it its own way, but it is inconvenient if it cannot change the behavior here.

So this change is removing this responsibility from C++ API.