### PR TITLE
rust: Update bindgen to 0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please visit the [documentation].
 | **C**                         | C99, C11             | GCC 7+, clang 5+, MSVC 2017+ | Host- and VM-side |
 | **C++**                       | C++17                | GCC 7+, clang 5+, MSVC 2017+ | Host- and VM-side |
 | **Go** _(bindings)_           | 1.11+ (with modules) |                              | Host-side only    |
-| **Rust** _(bindings)_[¹](#n1) | 2018 edition         | 1.37.0 and newer             | VM-side only      |
+| **Rust** _(bindings)_[¹](#n1) | 2018 edition         | 1.47.0 and newer             | VM-side only      |
 | **Java** _(bindings)_[²](#n2) | 11                   |                              | Host-side only    |
 
 1. <sup id="n1">↑</sup> Rust support is limited and not complete yet, but it is mostly functional already. Breaking changes are possible at this stage.

--- a/bindings/rust/evmc-sys/Cargo.toml
+++ b/bindings/rust/evmc-sys/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["external-ffi-bindings"]
 edition = "2018"
 
 [build-dependencies]
-bindgen = "0.54.0"
+bindgen = "0.59"

--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -20,9 +20,9 @@ fn gen_bindings() {
         // force deriving the PratialEq trait on basic types (address, bytes32)
         .derive_partialeq(true)
         .opaque_type("evmc_host_context")
-        .whitelist_type("evmc_.*")
-        .whitelist_function("evmc_.*")
-        .whitelist_var("EVMC_ABI_VERSION")
+        .allowlist_type("evmc_.*")
+        .allowlist_function("evmc_.*")
+        .allowlist_var("EVMC_ABI_VERSION")
         // TODO: consider removing this
         .size_t_is_usize(true)
         .generate()


### PR DESCRIPTION
This also bumps the Rust minimum version requirement from 1.37 to 1.47

Co-authored-by: Artem Vorotnikov <artem@vorotnikov.me>