### PR TITLE
rust: Add READMEs to each of the crates

### DIFF
--- a/bindings/rust/evmc-declare/README.md
+++ b/bindings/rust/evmc-declare/README.md
@@ -1,0 +1,5 @@
+# evmc-declare
+
+This is a Rust interface to [EVMC](https://github.com/ethereum/evmc).
+
+This crate contains a declare macro for easily creating EVMC compatible VM implementations.

--- a/bindings/rust/evmc-sys/README.md
+++ b/bindings/rust/evmc-sys/README.md
@@ -1,0 +1,5 @@
+# evmc-sys
+
+This is a Rust interface to [EVMC](https://github.com/ethereum/evmc).
+
+This crate contains the low-level bindings (e.g. types) to EVMC.

--- a/bindings/rust/evmc-vm/README.md
+++ b/bindings/rust/evmc-vm/README.md
@@ -1,0 +1,5 @@
+# evmc-vm
+
+This is a Rust interface to [EVMC](https://github.com/ethereum/evmc).
+
+This crate contains the implementation helpers for the VM-side.


### PR DESCRIPTION
These are useful to show some content on crates.io, e.g. https://crates.io/crates/evmc-vm