### PR TITLE
tool: Use @file syntax to loading data from a file

### DIFF
--- a/include/evmc/tooling.hpp
+++ b/include/evmc/tooling.hpp
@@ -8,11 +8,11 @@
 
 namespace evmc::tooling
 {
-int run(evmc::VM& vm,
+int run(VM& vm,
         evmc_revision rev,
         int64_t gas,
-        const std::string& code_hex,
-        const std::string& input_hex,
+        bytes_view code,
+        bytes_view input,
         bool create,
         bool bench,
         std::ostream& out);

--- a/lib/tooling/run.cpp
+++ b/lib/tooling/run.cpp
@@ -59,25 +59,17 @@ auto bench(MockedHost& host,
 }
 }  // namespace
 
-int run(evmc::VM& vm,
+int run(VM& vm,
         evmc_revision rev,
         int64_t gas,
-        const std::string& code_hex,
-        const std::string& input_hex,
+        bytes_view code,
+        bytes_view input,
         bool create,
         bool bench,
         std::ostream& out)
 {
     out << (create ? "Creating and executing on " : "Executing on ") << rev << " with " << gas
         << " gas limit\n";
-
-    auto opt_code = from_hex(code_hex);
-    auto opt_input = from_hex(input_hex);
-    if (!opt_code || !opt_input)
-        throw std::invalid_argument{"invalid hex"};
-
-    const auto& code = *opt_code;
-    const auto& input = *opt_input;
 
     MockedHost host;
 

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -54,30 +54,30 @@ set_tests_properties(${PROJECT_NAME}/evmc-tool/explicit_empty_input PROPERTIES P
 add_evmc_tool_test(
     invalid_hex_code
     "--vm $<TARGET_FILE:evmc::example-vm> run 0x600"
-    "code: \\(invalid hex\\) OR \\(File does not exist: 0x600\\)"
+    "code: invalid hex"
 )
 
 add_evmc_tool_test(
     invalid_hex_input
     "--vm $<TARGET_FILE:evmc::example-vm> run 0x --input aa0y"
-    "--input: \\(invalid hex\\) OR \\(File does not exist: aa0y\\)"
+    "--input: invalid hex"
 )
 
 add_evmc_tool_test(
     code_from_file
-    "--vm $<TARGET_FILE:evmc::example-vm> run ${CMAKE_CURRENT_SOURCE_DIR}/code.hex --input 0xaabbccdd"
+    "--vm $<TARGET_FILE:evmc::example-vm> run @${CMAKE_CURRENT_SOURCE_DIR}/code.hex --input 0xaabbccdd"
     "Result: +success[\r\n]+Gas used: +7[\r\n]+Output: +aabbccdd00000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 
 add_evmc_tool_test(
     input_from_file
-    "--vm $<TARGET_FILE:evmc::example-vm> run 600035600052596000f3 --input ${CMAKE_CURRENT_SOURCE_DIR}/input.hex"
+    "--vm $<TARGET_FILE:evmc::example-vm> run 600035600052596000f3 --input @${CMAKE_CURRENT_SOURCE_DIR}/input.hex"
     "Result: +success[\r\n]+Gas used: +7[\r\n]+Output: +aabbccdd00000000000000000000000000000000000000000000000000000000[\r\n]"
 )
 
 add_evmc_tool_test(
     invalid_code_file
-    "--vm $<TARGET_FILE:evmc::example-vm> run ${CMAKE_CURRENT_SOURCE_DIR}/invalid_code.evm"
+    "--vm $<TARGET_FILE:evmc::example-vm> run @${CMAKE_CURRENT_SOURCE_DIR}/invalid_code.evm"
     "Error: invalid hex"
 )
 

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -78,7 +78,7 @@ add_evmc_tool_test(
 add_evmc_tool_test(
     invalid_code_file
     "--vm $<TARGET_FILE:evmc::example-vm> run @${CMAKE_CURRENT_SOURCE_DIR}/invalid_code.evm"
-    "Error: invalid hex"
+    "Error: invalid hex in ${CMAKE_CURRENT_SOURCE_DIR}/invalid_code.evm"
 )
 
 add_evmc_tool_test(

--- a/test/unittests/tooling_test.cpp
+++ b/test/unittests/tooling_test.cpp
@@ -3,11 +3,13 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include "examples/example_vm/example_vm.h"
+#include <evmc/hex.hpp>
 #include <evmc/tooling.hpp>
 #include <gtest/gtest.h>
 #include <sstream>
 
 using namespace evmc::tooling;
+using evmc::from_hex;
 
 namespace
 {
@@ -33,7 +35,7 @@ TEST(tool_commands, run_empty_code)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_FRONTIER, 1, "", "", false, false, out);
+    const auto exit_code = run(vm, EVMC_FRONTIER, 1, {}, {}, false, false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(), out_pattern("Frontier", 1, "success", 0, ""));
 }
@@ -43,7 +45,8 @@ TEST(tool_commands, run_oog)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_BERLIN, 2, "0x6002600201", "", false, false, out);
+    const auto exit_code =
+        run(vm, EVMC_BERLIN, 2, *from_hex("0x6002600201"), {}, false, false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(), out_pattern("Berlin", 2, "out of gas", 2));
 }
@@ -53,7 +56,8 @@ TEST(tool_commands, run_return_my_address)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_HOMESTEAD, 200, "30600052596000f3", "", false, false, out);
+    const auto exit_code =
+        run(vm, EVMC_HOMESTEAD, 200, *from_hex("30600052596000f3"), {}, false, false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(),
               out_pattern("Homestead", 200, "success", 6,
@@ -67,8 +71,9 @@ TEST(tool_commands, run_copy_input_to_output)
     std::ostringstream out;
 
     const auto exit_code =
-        run(vm, EVMC_TANGERINE_WHISTLE, 200, "600035600052596000f3",
-            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", false, false, out);
+        run(vm, EVMC_TANGERINE_WHISTLE, 200, *from_hex("600035600052596000f3"),
+            *from_hex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"), false,
+            false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(),
               out_pattern("Tangerine Whistle", 200, "success", 7,
@@ -82,8 +87,9 @@ TEST(tool_commands, create_return_1)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_SPURIOUS_DRAGON, 200,
-                               "6960016000526001601ff3600052600a6016f3", "", true, false, out);
+    const auto exit_code =
+        run(vm, EVMC_SPURIOUS_DRAGON, 200, *from_hex("6960016000526001601ff3600052600a6016f3"), {},
+            true, false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(), out_pattern("Spurious Dragon", 200, "success", 6, "01", true));
 }
@@ -96,8 +102,8 @@ TEST(tool_commands, create_copy_input_to_output)
     std::ostringstream out;
 
     const auto exit_code =
-        run(vm, EVMC_SPURIOUS_DRAGON, 200, "69600035600052596000f3600052600a6016f3", "0c49c4", true,
-            false, out);
+        run(vm, EVMC_SPURIOUS_DRAGON, 200, *from_hex("69600035600052596000f3600052600a6016f3"),
+            *from_hex("0c49c4"), true, false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(
         out.str(),
@@ -112,7 +118,7 @@ TEST(tool_commands, create_failure_stack_underflow)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_PETERSBURG, 0, "fe", "", true, false, out);
+    const auto exit_code = run(vm, EVMC_PETERSBURG, 0, *from_hex("fe"), {}, true, false, out);
     EXPECT_EQ(exit_code, EVMC_UNDEFINED_INSTRUCTION);
     EXPECT_EQ(out.str(),
               "Creating and executing on Petersburg with 0 gas limit\n"
@@ -127,8 +133,9 @@ TEST(tool_commands, create_preserve_storage)
     std::ostringstream out;
 
     const auto exit_code =
-        run(vm, EVMC_BERLIN, 200, "60bb 6000 55 6a6000546000526001601ff3 6000 52 600b 6015 f3", "",
-            true, false, out);
+        run(vm, EVMC_BERLIN, 200,
+            *from_hex("60bb 6000 55 6a6000546000526001601ff3 6000 52 600b 6015 f3"), {}, true,
+            false, out);
     EXPECT_EQ(exit_code, 0);
     EXPECT_EQ(out.str(), out_pattern("Berlin", 200, "success", 7, "bb", true));
 }
@@ -138,7 +145,7 @@ TEST(tool_commands, bench_add)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto exit_code = run(vm, EVMC_LONDON, 200, "6002 80 01", "", false, true, out);
+    const auto exit_code = run(vm, EVMC_LONDON, 200, *from_hex("6002 80 01"), {}, false, true, out);
     EXPECT_EQ(exit_code, 0);
 
     const auto o = out.str();
@@ -153,8 +160,8 @@ TEST(tool_commands, bench_inconsistent_output)
     auto vm = evmc::VM{evmc_create_example_vm()};
     std::ostringstream out;
 
-    const auto code = "6000 54 6001 6000 55 6000 52 6001 601f f3";
-    const auto exit_code = run(vm, EVMC_BYZANTIUM, 200, code, "", false, true, out);
+    const auto code = *from_hex("6000 54 6001 6000 55 6000 52 6001 601f f3");
+    const auto exit_code = run(vm, EVMC_BYZANTIUM, 200, code, {}, false, true, out);
     EXPECT_EQ(exit_code, 0);
 
     const auto o = out.str();


### PR DESCRIPTION
For `--input` and `code` arguments allow loading data from a file by preceding the file path with @ character. E.g. `--input @sha1.in`.

Change the type of code and input parameters of `tooling::run()` from hex-encoded string to bytes. The hex decoding must happen outside. This moves the hex decoding errors out of the function concern.