### PR TITLE
Fix java bindings

### DIFF
--- a/bindings/java/c/evmc-vm.c
+++ b/bindings/java/c/evmc-vm.c
@@ -97,7 +97,8 @@ JNIEXPORT jobject JNICALL Java_org_ethereum_evmc_EvmcVm_execute(JNIEnv* jenv,
                                                                 jobject jcontext,
                                                                 jint jrev,
                                                                 jobject jmsg,
-                                                                jobject jcode)
+                                                                jobject jcode,
+                                                                jobject jinput_data)
 {
     (void)jcls;
     struct evmc_message* msg = (struct evmc_message*)(*jenv)->GetDirectBufferAddress(jenv, jmsg);
@@ -112,6 +113,7 @@ JNIEXPORT jobject JNICALL Java_org_ethereum_evmc_EvmcVm_execute(JNIEnv* jenv,
     struct evmc_result* result =
         (struct evmc_result*)(*jenv)->GetDirectBufferAddress(jenv, jresult);
     assert(result != NULL);
+    msg->input_data = GetDirectBuffer(jenv, jinput_data, &msg->input_size);
     *result = evmc_execute(evm, host, (struct evmc_host_context*)jcontext, (enum evmc_revision)jrev,
                            msg, code, code_size);
     return jresult;

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -166,8 +166,6 @@ static evmc_uint256be get_balance_fn(struct evmc_host_context* context, const ev
     evmc_uint256be result;
     CopyFromByteBuffer(jenv, jresult, &result, sizeof(evmc_uint256be));
 
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-
     return result;
 }
 
@@ -225,8 +223,6 @@ static evmc_bytes32 get_code_hash_fn(struct evmc_host_context* context, const ev
     evmc_bytes32 result;
     CopyFromByteBuffer(jenv, jresult, &result, sizeof(evmc_bytes32));
 
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
-
     return result;
 }
 
@@ -275,8 +271,6 @@ static size_t copy_code_fn(struct evmc_host_context* context,
         if (length > 0)
             memcpy(buffer_data, code + code_offset, length);
     }
-
-    (*jenv)->ReleaseByteArrayElements(jenv, jaddress, (jbyte*)address, 0);
 
     return length;
 }

--- a/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
@@ -157,8 +157,8 @@ public final class EvmcVm implements AutoCloseable {
    * <p>This allows the context to managed in one method
    */
   public synchronized ByteBuffer execute(
-      HostContext context, int rev, ByteBuffer msg, ByteBuffer code, ByteBuffer inputdata) {
-    return execute(nativeVm, context, rev, msg, code, inputdata);
+      HostContext context, int rev, ByteBuffer msg, ByteBuffer code, ByteBuffer input_data) {
+    return execute(nativeVm, context, rev, msg, code, input_data);
   }
 
   /**

--- a/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/EvmcVm.java
@@ -144,7 +144,12 @@ public final class EvmcVm implements AutoCloseable {
    * <p>This is a mandatory method and MUST NOT be set to NULL.
    */
   private static native ByteBuffer execute(
-      ByteBuffer nativeVm, HostContext context, int rev, ByteBuffer msg, ByteBuffer code);
+      ByteBuffer nativeVm,
+      HostContext context,
+      int rev,
+      ByteBuffer msg,
+      ByteBuffer code,
+      ByteBuffer input_data);
 
   /**
    * Function is a wrapper around native execute.
@@ -152,8 +157,8 @@ public final class EvmcVm implements AutoCloseable {
    * <p>This allows the context to managed in one method
    */
   public synchronized ByteBuffer execute(
-      HostContext context, int rev, ByteBuffer msg, ByteBuffer code) {
-    return execute(nativeVm, context, rev, msg, code);
+      HostContext context, int rev, ByteBuffer msg, ByteBuffer code, ByteBuffer inputdata) {
+    return execute(nativeVm, context, rev, msg, code, inputdata);
   }
 
   /**

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/EvmcTest.java
@@ -70,17 +70,22 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
 
       byte[] code = {0x30, 0x60, 0x00, 0x52, 0x59, 0x60, 0x00, (byte) 0xf3}; // return_address
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();
@@ -100,17 +105,22 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
 
       byte[] code = {0x60, 0x01, 0x60, 0x00, 0x54, 0x01, 0x60, 0x00, 0x55}; // counter
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();
@@ -130,17 +140,22 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
 
       byte[] code = {0x43, 0x60, 0x00, 0x52, 0x59, 0x60, 0x00, (byte) 0xf3}; // return_block_number(
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();
@@ -160,11 +175,15 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
 
       byte[] code = {
         0x43, 0x60, 0x00, 0x55, 0x43, 0x60, 0x00, 0x52, 0x59, 0x60, 0x00, (byte) 0xf3
@@ -172,7 +191,8 @@ final class EvmcTest {
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();
@@ -192,11 +212,15 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
       byte[] code = {
         0x60,
         0x00,
@@ -211,7 +235,8 @@ final class EvmcTest {
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();
@@ -230,16 +255,21 @@ final class EvmcTest {
       char[] sender = "39bf71de1b7d7be3b51\\0".toCharArray();
       char[] recipient = "53cf77204eEef952e25\0".toCharArray();
       char[] value = "1\0".toCharArray();
-      char[] inputData = "hello w\0".toCharArray();
+      char[] inputDataPlaceholder = {};
+      byte[] inputDataBytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+      ByteBuffer inputDataByteBuffer =
+          ByteBuffer.wrap(inputDataBytes).order(ByteOrder.nativeOrder());
       long gas = 200000;
       int depth = 0;
       ByteBuffer msg =
-          new TestMessage(kind, sender, recipient, value, inputData, gas, depth).toByteBuffer();
+          new TestMessage(kind, sender, recipient, value, inputDataPlaceholder, gas, depth)
+              .toByteBuffer();
       byte[] code = {0x00};
       ByteBuffer bbcode = ByteBuffer.allocateDirect(code.length).put(code);
 
       ByteBuffer result =
-          vm.execute(context, BYZANTIUM, msg, bbcode).order(ByteOrder.nativeOrder());
+          vm.execute(context, BYZANTIUM, msg, bbcode, inputDataByteBuffer)
+              .order(ByteOrder.nativeOrder());
       int statusCode = result.getInt();
       result.getInt(); // padding
       long gasLeft = result.getLong();


### PR DESCRIPTION
1. `vm_execute` input data was not handled properly. An additional `inputData` parameter has been added to `EvmcVm`'s `execute` function to avoid pointer arithmetics in java
2. `ReleaseByteArrayElements` was called on a pointer that is not derived from `GetByteArrayElements` causing segfaults
3. `get_block_hash_fn` typo

Also, it was quite challenging to encode `evmc_message` into ByteBuffer and then decode the result. I'd suggest capturing that logic into java classes so the callers won't have to work with memory buffers directly.