### PR TITLE
java: Fix get_block_hash implementation

### DIFF
--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -369,7 +369,7 @@ static struct evmc_tx_context get_tx_context_fn(struct evmc_host_context* contex
 
 static evmc_bytes32 get_block_hash_fn(struct evmc_host_context* context, int64_t number)
 {
-    char java_method_name[] = "get_code_hash";
+    char java_method_name[] = "get_block_hash";
     char java_method_signature[] = "(Lorg/ethereum/evmc/HostContext;J)Ljava/nio/ByteBuffer;";
 
     assert(context != NULL);

--- a/bindings/java/java/src/main/java/org/ethereum/evmc/Host.java
+++ b/bindings/java/java/src/main/java/org/ethereum/evmc/Host.java
@@ -69,7 +69,7 @@ final class Host {
   }
 
   /** Get block hash callback function. */
-  static ByteBuffer get_block_hash_fn(HostContext context, long number) {
+  static ByteBuffer get_block_hash(HostContext context, long number) {
     return ensureDirectBuffer(context.getBlockHash(number));
   }
 


### PR DESCRIPTION
It used to have a typo triggering get_code_hash. Also removed the _fn suffix.

Pulled from #651.