### PR TITLE
C++: Add convenient result constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@ and this project adheres to [Semantic Versioning].
   [#617](https://github.com/ethereum/evmc/pull/617)
 - Support for Visual Studio 2022.
   [#619](https://github.com/ethereum/evmc/pull/619)
-- C++ types `evmc::address` and `evmc::bytes32` are convertible to `std::basic_string_view<uint8_t>`.
+- C++ types `evmc::address` and `evmc::bytes32` are convertible to `std::basic_string_view<uint8_t>`
+  .
   [#636](https://github.com/ethereum/evmc/pull/636)
+- Convenient constructors for C++ `evmc::result`.
+  [#660](https://github.com/ethereum/evmc/pull/660)
 - Rust: The `EvmcVm::set_option` has been added.
   [#614](https://github.com/ethereum/evmc/pull/614)
 

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -133,7 +133,7 @@ public:
 
     evmc::result call(const evmc_message& msg) noexcept final
     {
-        return {EVMC_REVERT, msg.gas, msg.input_data, msg.input_size};
+        return evmc::result{EVMC_REVERT, msg.gas, msg.input_data, msg.input_size};
     }
 
     evmc_tx_context get_tx_context() const noexcept final { return tx_context; }

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -443,12 +443,11 @@ struct evmc_result
     evmc_release_result_fn release;
 
     /**
-     * The address of the contract created by create instructions.
+     * The address of the possibly created contract.
      *
-     * This field has valid value only if:
-     * - it is a result of the Host method evmc_host_interface::call
-     * - and the result describes successful contract creation
-     *   (evmc_result::status_code is ::EVMC_SUCCESS).
+     * The create address may be provided even though the contract creation has failed
+     * (evmc_result::status_code is not ::EVMC_SUCCESS). This is useful in situations
+     * when the address is observable, e.g. access to it remains warm.
      * In all other cases the address MUST be null bytes.
      */
     evmc_address create_address;

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -354,7 +354,9 @@ public:
     {}
 
     /// Converting constructor from raw evmc_result.
-    explicit result(evmc_result const& res) noexcept : evmc_result{res} {}
+    ///
+    /// This object takes ownership of the resources of @p res.
+    explicit result(const evmc_result& res) noexcept : evmc_result{res} {}
 
     /// Destructor responsible for automatically releasing attached resources.
     ~result() noexcept
@@ -371,7 +373,7 @@ public:
 
     /// Move assignment operator.
     ///
-    /// The self-assigment MUST never happen.
+    /// The self-assignment MUST never happen.
     ///
     /// @param other The other result object.
     /// @return      The reference to the left-hand side object.

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -346,12 +346,34 @@ public:
     /// @param _gas_left     The amount of gas left.
     /// @param _output_data  The pointer to the output.
     /// @param _output_size  The output size.
-    result(evmc_status_code _status_code,
-           int64_t _gas_left,
-           const uint8_t* _output_data,
-           size_t _output_size) noexcept
+    explicit result(evmc_status_code _status_code,
+                    int64_t _gas_left,
+                    const uint8_t* _output_data,
+                    size_t _output_size) noexcept
       : evmc_result{make_result(_status_code, _gas_left, _output_data, _output_size)}
     {}
+
+    /// Creates the result without output.
+    ///
+    /// @param _status_code  The status code.
+    /// @param _gas_left     The amount of gas left.
+    explicit result(evmc_status_code _status_code = EVMC_INTERNAL_ERROR,
+                    int64_t _gas_left = 0) noexcept
+      : evmc_result{make_result(_status_code, _gas_left, nullptr, 0)}
+    {}
+
+    /// Creates the result of contract creation.
+    ///
+    /// @param _status_code     The status code.
+    /// @param _gas_left        The amount of gas left.
+    /// @param _create_address  The address of the possibly created account.
+    explicit result(evmc_status_code _status_code,
+                    int64_t _gas_left,
+                    const evmc_address& _create_address) noexcept
+      : evmc_result{make_result(_status_code, _gas_left, nullptr, 0)}
+    {
+        create_address = _create_address;
+    }
 
     /// Converting constructor from raw evmc_result.
     ///

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -54,10 +54,7 @@ public:
                       const evmc::address& /*beneficiary*/) noexcept final
     {}
 
-    evmc::result call(const evmc_message& /*msg*/) noexcept final
-    {
-        return evmc::result{evmc_result{}};
-    }
+    evmc::result call(const evmc_message& /*msg*/) noexcept final { return evmc::result{}; }
 
     evmc_tx_context get_tx_context() const noexcept final { return {}; }
 
@@ -788,7 +785,7 @@ TEST(cpp, result_move)
 
 TEST(cpp, result_create_no_output)
 {
-    auto r = evmc::result{EVMC_REVERT, 1, nullptr, 0};
+    auto r = evmc::result{EVMC_REVERT, 1};
     EXPECT_EQ(r.status_code, EVMC_REVERT);
     EXPECT_EQ(r.gas_left, 1);
     EXPECT_FALSE(r.output_data);


### PR DESCRIPTION
New constructors are added based on the usage in state transition implementation in evmone.