### PR TITLE
Extend storage status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning].
 - The `evmc_message::destination` field has been renamed to `evmc_message::recipient`
   to clarify its purpose and match the naming from the Yellow Paper.
   [#616](https://github.com/ethereum/evmc/pull/616)
+- The `evmc_storage_status` has been extended to provide information about every possible case of 
+  storage net gas metering ([EIP-2200](https://eips.ethereum.org/EIPS/eip-2200)).
+  [#661](https://github.com/ethereum/evmc/pull/661)
 - The `selfdestruct` method returns the information if the given address
   has not been registered as selfdestructed yet.
   [#662](https://github.com/ethereum/evmc/pull/662)

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -36,11 +36,15 @@ const (
 type StorageStatus int
 
 const (
-	StorageUnchanged     StorageStatus = C.EVMC_STORAGE_UNCHANGED
-	StorageModified      StorageStatus = C.EVMC_STORAGE_MODIFIED
-	StorageModifiedAgain StorageStatus = C.EVMC_STORAGE_MODIFIED_AGAIN
-	StorageAdded         StorageStatus = C.EVMC_STORAGE_ADDED
-	StorageDeleted       StorageStatus = C.EVMC_STORAGE_DELETED
+	StorageAssigned         StorageStatus = C.EVMC_STORAGE_ASSIGNED
+	StorageAdded            StorageStatus = C.EVMC_STORAGE_ADDED
+	StorageDeleted          StorageStatus = C.EVMC_STORAGE_DELETED
+	StorageModified         StorageStatus = C.EVMC_STORAGE_MODIFIED
+	StorageDeletedAdded     StorageStatus = C.EVMC_STORAGE_DELETED_ADDED
+	StorageModifiedDeleted  StorageStatus = C.EVMC_STORAGE_MODIFIED_DELETED
+	StorageDeletedRestored  StorageStatus = C.EVMC_STORAGE_DELETED_RESTORED
+	StorageAddedDeleted     StorageStatus = C.EVMC_STORAGE_ADDED_DELETED
+	StorageModifiedRestored StorageStatus = C.EVMC_STORAGE_MODIFIED_RESTORED
 )
 
 func goAddress(in C.evmc_address) Address {

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -20,7 +20,7 @@ func (host *testHostContext) GetStorage(addr Address, key Hash) Hash {
 }
 
 func (host *testHostContext) SetStorage(addr Address, key Hash, value Hash) (status StorageStatus) {
-	return StorageUnchanged
+	return StorageAssigned
 }
 
 func (host *testHostContext) GetBalance(addr Address) Hash {

--- a/bindings/rust/evmc-vm/src/types.rs
+++ b/bindings/rust/evmc-vm/src/types.rs
@@ -99,8 +99,8 @@ mod tests {
     #[test]
     fn storage_status() {
         assert_eq!(
-            StorageStatus::EVMC_STORAGE_UNCHANGED,
-            ffi::evmc_storage_status::EVMC_STORAGE_UNCHANGED
+            StorageStatus::EVMC_STORAGE_ASSIGNED,
+            ffi::evmc_storage_status::EVMC_STORAGE_ASSIGNED
         );
         assert_eq!(
             StorageStatus::EVMC_STORAGE_MODIFIED,

--- a/docs/EVM_Storage_Change_Status.md
+++ b/docs/EVM_Storage_Change_Status.md
@@ -1,0 +1,333 @@
+# EVM Storage Change Status {#storagestatus}
+
+The description of ::evmc_storage_status enum design and its relation
+to the specification in [EIP-2200] and others.
+
+## Specification
+
+> This is the [EIP-2200] specification with modifications:
+> - the clause tree has been converted to ordered lists to be referenceable,
+> - the cost constant names has been replaced with matching Yellow Paper names.
+
+1. If *gasleft* is less than or equal to gas stipend, fail the current
+   call frame with 'out of gas' exception.
+2. If *current value* equals *new value* (this is a no-op), G<sub>warmaccess</sub>
+   is deducted.
+3. If *current value* does not equal *new value*
+    1. If *original value* equals *current value* (this storage slot has
+       not been changed by the current execution context)
+        1. If *original value* is 0, G<sub>sset</sub> is deducted.
+        2. Otherwise, G<sub>sreset</sub> gas is deducted.
+            1. If *new value* is 0,
+               add R<sub>sclear</sub> gas to refund counter.
+    2. If *original value* does not equal *current value* (this storage
+       slot is dirty), G<sub>warmaccess</sub> gas is deducted. Apply both of the
+       following clauses.
+        1. If *original value* is not 0
+            1. If *current value* is 0 (also means that *new value* is not
+               0), remove R<sub>sclear</sub> gas from refund
+               counter.
+            2. If *new value* is 0 (also means that *current value* is not
+               0), add R<sub>sclear</sub> gas to refund counter.
+        2. If *original value* equals *new value* (this storage slot is
+           reset)
+            1. If *original value* is 0, add G<sub>sset</sub> - G<sub>warmaccess</sub> to
+               refund counter.
+            2. Otherwise, add G<sub>sreset</sub> - G<sub>warmaccess</sub> gas to refund
+               counter.
+
+### Cost constants
+
+| Yellow Paper           | EIP-2200                  | EIP-2200 Value | EIP-2929 Value |
+|------------------------|---------------------------|----------------|----------------|
+| G<sub>warmaccess</sub> | `SLOAD_GAS`               | 800            | 100            |
+| G<sub>sset</sub>       | `SSTORE_SET_GAS`          | 20000          | 20000          |
+| G<sub>sreset</sub>     | `SSTORE_RESET_GAS`        | 5000           | 2900           |
+| R<sub>sclear</sub>     | `SSTORE_CLEARS_SCHEDULE`  | 15000          | 15000          |
+
+## Storage change statuses
+
+- `0` - zero value
+- `X` - non-zero value
+- `Y` - non-zero value different from `X`
+- `Z` - non-zero value different form `X` and `Y`
+- `o` - original value
+- `c` - current value
+- `v` - new value
+
+<table>
+    <tr>
+        <th>name</th>
+        <th>o</th>
+        <th>c</th>
+        <th>v</th>
+        <th>dirty</th>
+        <th>restored</th>
+        <th>clause</th>
+        <th>gas cost</th>
+        <th>gas refund</th>
+    </tr>
+    <tr>
+        <td rowspan="7">[ASSIGNED]</td>
+        <td>0</td><td>0</td><td>0</td>
+        <td>no</td>
+        <td>yes</td>
+        <td>2</td>
+        <td rowspan="7">G<sub>warmaccess</sub></td>
+        <td rowspan="7">0</td>
+    </tr>
+    <tr>
+        <td>X</td><td>0</td><td>0</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>0</td><td>Y</td><td>Y</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>X</td><td>Y</td><td>Y</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>Y</td><td>Y</td><td>Y</td>
+        <td>no</td>
+        <td>yes</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>0</td><td>Y</td><td>Z</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>3.2</td>
+    </tr>
+    <tr>
+        <td>X</td><td>Y</td><td>Z</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>3.2</td>
+    </tr>
+    <tr>
+        <td>[ADDED]</td>
+        <td>0</td><td>0</td><td>Z</td>
+        <td>no</td>
+        <td>no</td>
+        <td>3.1.1</td>
+        <td>G<sub>sset</sub></td>
+        <td>0</td>
+    </tr>
+    <tr>
+        <td>[DELETED]</td>
+        <td>X</td><td>X</td><td>0</td>
+        <td>no</td>
+        <td>no</td>
+        <td>3.1.2.1</td>
+        <td>G<sub>sreset</sub></td>
+        <td>R<sub>sclear</sub></td>
+    </tr>
+    <tr>
+        <td>[MODIFIED]</td>
+        <td>X</td><td>X</td><td>Z</td>
+        <td>no</td>
+        <td>no</td>
+        <td>3.1.2</td>
+        <td>G<sub>sreset</sub></td>
+        <td>0</td>
+    </tr>
+    <tr>
+        <td>[DELETED_ADDED]</td>
+        <td>X</td><td>0</td><td>Z</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>3.2.1.1</td>
+        <td>G<sub>warmaccess</sub></td>
+        <td>-R<sub>sclear</sub></td>
+    </tr>
+    <tr>
+        <td>[MODIFIED_DELETED]</td>
+        <td>X</td><td>Y</td><td>0</td>
+        <td>yes</td>
+        <td>no</td>
+        <td>3.2.1.2</td>
+        <td>G<sub>warmaccess</sub></td>
+        <td>R<sub>sclear</sub></td>
+    </tr>
+    <tr>
+        <td>[DELETED_RESTORED]</td>
+        <td>X</td><td>0</td><td>X</td>
+        <td>yes</td>
+        <td>yes</td>
+        <td>3.2.1.1 + 3.2.2.2</td>
+        <td>G<sub>warmaccess</sub></td>
+        <td>-R<sub>sclear</sub> + G<sub>sreset</sub> - G<sub>warmaccess</sub></td>
+    </tr>
+    <tr>
+        <td>[ADDED_DELETED]</td>
+        <td>0</td><td>Y</td><td>0</td>
+        <td>yes</td>
+        <td>yes</td>
+        <td>3.2.2.1</td>
+        <td>G<sub>warmaccess</sub></td>
+        <td>G<sub>sset</sub> - G<sub>warmaccess</sub></td>
+    </tr>
+    <tr>
+        <td>[MODIFIED_RESTORED]</td>
+        <td>X</td><td>Y</td><td>X</td>
+        <td>yes</td>
+        <td>yes</td>
+        <td>3.2.2.2</td>
+        <td>G<sub>warmaccess</sub></td>
+        <td>G<sub>sreset</sub> - G<sub>warmaccess</sub></td>
+    </tr>
+</table>
+
+
+## Efficient implementation
+
+All distinctive storage change statuses can be unambiguously selected
+by combination of the 4 following checks:
+- **o ≠ c**, i.e. `original != current` (dirty),
+- **o = v**, i.e `original == new` (restored),
+- **c ≠ 0**, i.e `current != 0`,
+- **v ≠ 0**, i.e `new != 0`.
+
+<table>
+    <tr>
+        <th>name</th>
+        <th>o</th>
+        <th>c</th>
+        <th>v</th>
+        <th>o ≠ c</th>
+        <th>o = v</th>
+        <th>c ≠ 0</th>
+        <th>v ≠ 0</th>
+        <th>checksum</th>
+        <th>proof</th>
+    </tr>
+    <tr>
+        <td rowspan="7">[ASSIGNED]</td>
+        <td>0</td><td>0</td><td>0</td>
+        <td>0</td><td>1</td><td>0</td><td>0</td>
+        <td>4 (0b0100)</td>
+    </tr>
+    <tr>
+        <td>X</td><td>0</td><td>0</td>
+        <td>1</td><td>0</td><td>0</td><td>0</td>
+        <td>8 (0b1000)</td>
+    </tr>
+    <tr>
+        <td>0</td><td>Y</td><td>Y</td>
+        <td>1</td><td>0</td><td>1</td><td>1</td>
+        <td>11 (0b1011)</td>
+    </tr>
+    <tr>
+        <td>X</td><td>Y</td><td>Y</td>
+        <td>1</td><td>0</td><td>1</td><td>1</td>
+        <td>11 (0b1011)</td>
+    </tr>
+    <tr>
+        <td>Y</td><td>Y</td><td>Y</td>
+        <td>0</td><td>1</td><td>1</td><td>1</td>
+        <td>7 (0b0111)</td>
+    </tr>
+    <tr>
+        <td>0</td><td>Y</td><td>Z</td>
+        <td>1</td><td>0</td><td>1</td><td>1</td>
+        <td>11 (0b1011)</td>
+    </tr>
+    <tr>
+        <td>X</td><td>Y</td><td>Z</td>
+        <td>1</td><td>0</td><td>1</td><td>1</td>
+        <td>11 (0b1011)</td>
+    </tr>
+    <tr>
+        <td>[ADDED]</td>
+        <td>0</td><td>0</td><td>Z</td>
+        <td>0</td><td>0</td><td>0</td><td>1</td>
+        <td>1 (0b0001)</td>
+    </tr>
+    <tr>
+        <td>[DELETED]</td>
+        <td>X</td><td>X</td><td>0</td>
+        <td>0</td><td>0</td><td>1</td><td>0</td>
+        <td>2 (0b0010)</td>
+    </tr>
+    <tr>
+        <td>[MODIFIED]</td>
+        <td>X</td><td>X</td><td>Z</td>
+        <td>0</td><td>0</td><td>1</td><td>1</td>
+        <td>3 (0b0011)</td>
+    </tr>
+    <tr>
+        <td>[DELETED_ADDED]</td>
+        <td>X</td><td>0</td><td>Z</td>
+        <td>1</td><td>0</td><td>0</td><td>1</td>
+        <td>9 (0b1001)</td>
+    </tr>
+    <tr>
+        <td>[MODIFIED_DELETED]</td>
+        <td>X</td><td>Y</td><td>0</td>
+        <td>1</td><td>0</td><td>1</td><td>0</td>
+        <td>10 (0b1010)</td>
+    </tr>
+    <tr>
+        <td>[DELETED_RESTORED]</td>
+        <td>X</td><td>0</td><td>X</td>
+        <td>1</td><td>1</td><td>0</td><td>1</td>
+        <td>13 (0b1101)</td>
+    </tr>
+    <tr>
+        <td>[ADDED_DELETED]</td>
+        <td>0</td><td>Y</td><td>0</td>
+        <td>1</td><td>1</td><td>1</td><td>0</td>
+        <td>14 (0b1110)</td>
+    </tr>
+    <tr>
+        <td>[MODIFIED_RESTORED]</td>
+        <td>X</td><td>Y</td><td>X</td>
+        <td>1</td><td>1</td><td>1</td><td>1</td>
+        <td>15 (0b1111)</td>
+    </tr>
+    <tr>
+        <td rowspan="4">impossible</td>
+        <td></td><td></td><td></td>
+        <td>0</td><td>0</td><td>0</td><td>0</td>
+        <td>0 (0b0000)</td>
+        <td>o=c ∧ o≠v ∧ c=0 ⇒ v≠0</td>
+    </tr>
+    <tr>
+        <td></td><td></td><td></td>
+        <td>0</td><td>1</td><td>0</td><td>1</td>
+        <td>5 (0b0101)</td>
+        <td>o=c ∧ o=v ∧ c=0 ⇒ v=0</td>
+    </tr>
+    <tr>
+        <td></td><td></td><td></td>
+        <td>0</td><td>1</td><td>1</td><td>0</td>
+        <td>6 (0b0110)</td>
+        <td>o=c ∧ o=v ∧ c≠0 ⇒ v≠0</td>
+    </tr>
+    <tr>
+        <td></td><td></td><td></td>
+        <td>1</td><td>1</td><td>0</td><td>0</td>
+        <td>12 (0b1100)</td>
+        <td>o≠c ∧ o=v ∧ c=0 ⇒ v≠0</td>
+    </tr>
+</table>
+
+
+[EIP-2200]: https://eips.ethereum.org/EIPS/eip-2200
+[ASSIGNED]: @ref EVMC_STORAGE_ASSIGNED
+[ADDED]: @ref EVMC_STORAGE_ADDED
+[DELETED]: @ref EVMC_STORAGE_DELETED
+[MODIFIED]: @ref EVMC_STORAGE_MODIFIED
+[DELETED_ADDED]: @ref EVMC_STORAGE_DELETED_ADDED
+[MODIFIED_DELETED]: @ref EVMC_STORAGE_MODIFIED_DELETED
+[DELETED_RESTORED]: @ref EVMC_STORAGE_DELETED_RESTORED
+[ADDED_DELETED]: @ref EVMC_STORAGE_ADDED_DELETED
+[MODIFIED_RESTORED]: @ref EVMC_STORAGE_MODIFIED_RESTORED

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -77,7 +77,7 @@ public:
         auto prev_value = account.storage[key];
         account.storage[key] = value;
 
-        return (prev_value == value) ? EVMC_STORAGE_UNCHANGED : EVMC_STORAGE_MODIFIED;
+        return (prev_value == value) ? EVMC_STORAGE_ASSIGNED : EVMC_STORAGE_MODIFIED;
     }
 
     evmc::uint256be get_balance(const evmc::address& addr) const noexcept final

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -181,7 +181,7 @@ public:
         // WARNING! This is not complete implementation as refund is not handled here.
 
         if (old.value == value)
-            return EVMC_STORAGE_UNCHANGED;
+            return EVMC_STORAGE_ASSIGNED;
 
         evmc_storage_status status{};
         if (!old.dirty)
@@ -195,7 +195,7 @@ public:
                 status = EVMC_STORAGE_DELETED;
         }
         else
-            status = EVMC_STORAGE_MODIFIED_AGAIN;
+            status = EVMC_STORAGE_ASSIGNED;
 
         old.value = value;
         return status;

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -5,6 +5,7 @@
 
 #include <evmc/evmc.hpp>
 #include <algorithm>
+#include <cassert>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -176,32 +177,141 @@ public:
     {
         record_account_access(addr);
 
-        // Get the reference to the old value.
+        // Get the reference to the storage entry value.
         // This will create the account in case it was not present.
         // This is convenient for unit testing and standalone EVM execution to preserve the
         // storage values after the execution terminates.
-        auto& old = accounts[addr].storage[key];
+        auto& s = accounts[addr].storage[key];
 
-        // Follow https://eips.ethereum.org/EIPS/eip-1283 specification.
-        // WARNING! This is not complete implementation as refund is not handled here.
+        // Follow the EIP-2200 specification as closely as possible.
+        // https://eips.ethereum.org/EIPS/eip-2200
+        // Warning: this is not the most efficient implementation. The storage status can be
+        // figured out by combining only 4 checks:
+        // - original != current (dirty)
+        // - original == value (restored)
+        // - current != 0
+        // - value != 0
+        const auto status = [&original = s.original, &current = s.current, &value]() {
+            // Clause 1 is irrelevant:
+            // 1. "If gasleft is less than or equal to gas stipend,
+            //    fail the current call frame with ‘out of gas’ exception"
 
-        if (old.current == value)
-            return EVMC_STORAGE_ASSIGNED;
-
-        evmc_storage_status status{};
-        if (old.original == old.current)
-        {
-            if (!old.current)
-                status = EVMC_STORAGE_ADDED;
-            else if (value)
-                status = EVMC_STORAGE_MODIFIED;
+            // 2. "If current value equals new value (this is a no-op)"
+            if (current == value)
+            {
+                // "SLOAD_GAS is deducted"
+                return EVMC_STORAGE_ASSIGNED;
+            }
+            // 3. "If current value does not equal new value"
             else
-                status = EVMC_STORAGE_DELETED;
-        }
-        else
-            status = EVMC_STORAGE_ASSIGNED;
+            {
+                // 3.1. "If original value equals current value
+                //      (this storage slot has not been changed by the current execution context)"
+                if (original == current)
+                {
+                    // 3.1.1 "If original value is 0"
+                    if (is_zero(original))
+                    {
+                        // "SSTORE_SET_GAS is deducted"
+                        return EVMC_STORAGE_ADDED;
+                    }
+                    // 3.1.2 "Otherwise"
+                    else
+                    {
+                        // "SSTORE_RESET_GAS gas is deducted"
+                        auto st = EVMC_STORAGE_MODIFIED;
 
-        old.current = value;
+                        // "If new value is 0"
+                        if (is_zero(value))
+                        {
+                            // "add SSTORE_CLEARS_SCHEDULE gas to refund counter"
+                            st = EVMC_STORAGE_DELETED;
+                        }
+
+                        return st;
+                    }
+                }
+                // 3.2. "If original value does not equal current value
+                //      (this storage slot is dirty),
+                //      SLOAD_GAS gas is deducted.
+                //      Apply both of the following clauses."
+                else
+                {
+                    // Because we need to apply "both following clauses"
+                    // we first collect information which clause is triggered
+                    // then assign status code to combination of these clauses.
+                    enum
+                    {
+                        None = 0,
+                        RemoveClearsSchedule = 1 << 0,
+                        AddClearsSchedule = 1 << 1,
+                        RestoredBySet = 1 << 2,
+                        RestoredByReset = 1 << 3,
+                    };
+                    int triggered_clauses = None;
+
+                    // 3.2.1. "If original value is not 0"
+                    if (!is_zero(original))
+                    {
+                        // 3.2.1.1. "If current value is 0"
+                        if (is_zero(current))
+                        {
+                            // "(also means that new value is not 0)"
+                            assert(!is_zero(value));
+                            // "remove SSTORE_CLEARS_SCHEDULE gas from refund counter"
+                            triggered_clauses |= RemoveClearsSchedule;
+                        }
+                        // 3.2.1.2. "If new value is 0"
+                        if (is_zero(value))
+                        {
+                            // "(also means that current value is not 0)"
+                            assert(!is_zero(current));
+                            // "add SSTORE_CLEARS_SCHEDULE gas to refund counter"
+                            triggered_clauses |= AddClearsSchedule;
+                        }
+                    }
+
+                    // 3.2.2. "If original value equals new value (this storage slot is reset)"
+                    // Except: we use term 'storage slot restored'.
+                    if (original == value)
+                    {
+                        // 3.2.2.1. "If original value is 0"
+                        if (is_zero(original))
+                        {
+                            // "add SSTORE_SET_GAS - SLOAD_GAS to refund counter"
+                            triggered_clauses |= RestoredBySet;
+                        }
+                        // 3.2.2.2. "Otherwise"
+                        else
+                        {
+                            // "add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter"
+                            triggered_clauses |= RestoredByReset;
+                        }
+                    }
+
+                    switch (triggered_clauses)
+                    {
+                    case RemoveClearsSchedule:
+                        return EVMC_STORAGE_DELETED_ADDED;
+                    case AddClearsSchedule:
+                        return EVMC_STORAGE_MODIFIED_DELETED;
+                    case RemoveClearsSchedule | RestoredByReset:
+                        return EVMC_STORAGE_DELETED_RESTORED;
+                    case RestoredBySet:
+                        return EVMC_STORAGE_ADDED_DELETED;
+                    case RestoredByReset:
+                        return EVMC_STORAGE_MODIFIED_RESTORED;
+                    case None:
+                        return EVMC_STORAGE_ASSIGNED;
+                    default:
+                        assert(false);  // Other combinations are impossible.
+                        return evmc_storage_status{};
+                    }
+                }
+            }
+        }();
+
+        s.current = value;  // Finally update the current storage value.
         return status;
     }
 
@@ -348,16 +458,18 @@ public:
 
     /// Access the account's storage value at the given key.
     ///
-    /// This method is required by EIP-2929 introduced in ::EVMC_BERLIN. In records that the given
-    /// account's storage key has been access and returns the previous access status.
-    /// To mock storage access list (EIP-2930), you can pre-init account's storage values with
-    /// the ::EVMC_ACCESS_WARM flag:
+    /// This method is required by EIP-2929 introduced in ::EVMC_BERLIN. In records
+    /// that the given account's storage key has been access and returns the
+    /// previous access status. To mock storage access list (EIP-2930), you can
+    /// pre-init account's storage values with the ::EVMC_ACCESS_WARM flag:
     ///
-    ///     mocked_host.accounts[msg.recipient].storage[key] = {value, EVMC_ACCESS_WARM};
+    ///     mocked_host.accounts[msg.recipient].storage[key] = {value,
+    ///     EVMC_ACCESS_WARM};
     ///
     /// @param addr  The account address.
     /// @param key   The account's storage key.
-    /// @return      The ::EVMC_ACCESS_WARM if the storage key has been accessed before,
+    /// @return      The ::EVMC_ACCESS_WARM if the storage key has been accessed
+    /// before,
     ///              the ::EVMC_ACCESS_COLD otherwise.
     evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept override
     {

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -14,29 +14,34 @@ namespace evmc
 /// The string of bytes.
 using bytes = std::basic_string<uint8_t>;
 
-/// Extended value (by dirty flag) for account storage.
-struct storage_value
+/// Extended value (with original value and access flag) for account storage.
+struct StorageValue
 {
-    /// The storage value.
-    bytes32 value;
+    /// The current storage value.
+    bytes32 current;
 
-    /// True means this value has been modified already by the current transaction.
-    bool dirty{false};
+    /// The original storage value.
+    bytes32 original;
 
     /// Is the storage key cold or warm.
     evmc_access_status access_status{EVMC_ACCESS_COLD};
 
     /// Default constructor.
-    storage_value() noexcept = default;
+    StorageValue() noexcept = default;
 
     /// Constructor.
-    storage_value(const bytes32& _value, bool _dirty = false) noexcept  // NOLINT
-      : value{_value}, dirty{_dirty}
+    StorageValue(const bytes32& _value) noexcept  // NOLINT
+      : current{_value}, original{_value}
+    {}
+
+    /// Constructor with original value.
+    StorageValue(const bytes32& _value, const bytes32& _original) noexcept
+      : current{_value}, original{_original}
     {}
 
     /// Constructor with initial access status.
-    storage_value(const bytes32& _value, evmc_access_status _access_status) noexcept
-      : value{_value}, access_status{_access_status}
+    StorageValue(const bytes32& _value, evmc_access_status _access_status) noexcept
+      : current{_value}, original{_value}, access_status{_access_status}
     {}
 };
 
@@ -56,7 +61,7 @@ struct MockedAccount
     uint256be balance;
 
     /// The account storage map.
-    std::unordered_map<bytes32, storage_value> storage;
+    std::unordered_map<bytes32, StorageValue> storage;
 
     /// Helper method for setting balance by numeric type.
     void set_balance(uint64_t x) noexcept
@@ -160,7 +165,7 @@ public:
 
         const auto storage_iter = account_iter->second.storage.find(key);
         if (storage_iter != account_iter->second.storage.end())
-            return storage_iter->second.value;
+            return storage_iter->second.current;
         return {};
     }
 
@@ -180,14 +185,13 @@ public:
         // Follow https://eips.ethereum.org/EIPS/eip-1283 specification.
         // WARNING! This is not complete implementation as refund is not handled here.
 
-        if (old.value == value)
+        if (old.current == value)
             return EVMC_STORAGE_ASSIGNED;
 
         evmc_storage_status status{};
-        if (!old.dirty)
+        if (old.original == old.current)
         {
-            old.dirty = true;
-            if (!old.value)
+            if (!old.current)
                 status = EVMC_STORAGE_ADDED;
             else if (value)
                 status = EVMC_STORAGE_MODIFIED;
@@ -197,7 +201,7 @@ public:
         else
             status = EVMC_STORAGE_ASSIGNED;
 
-        old.value = value;
+        old.current = value;
         return status;
     }
 

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -645,7 +645,7 @@ TEST(cpp, host)
     EXPECT_TRUE(host.account_exists(a));
 
     EXPECT_EQ(host.set_storage(a, {}, v), EVMC_STORAGE_MODIFIED);
-    EXPECT_EQ(host.set_storage(a, {}, v), EVMC_STORAGE_UNCHANGED);
+    EXPECT_EQ(host.set_storage(a, {}, v), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(host.get_storage(a, {}), v);
 
     EXPECT_TRUE(evmc::is_zero(host.get_balance(a)));

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -18,6 +18,8 @@
 #include <map>
 #include <unordered_map>
 
+using namespace evmc::literals;
+
 class NullHost : public evmc::Host
 {
 public:
@@ -641,7 +643,7 @@ TEST(cpp, host)
 
     EXPECT_FALSE(host.account_exists(a));
 
-    mockedHost.accounts[a].storage[{}].value.bytes[0] = 1;
+    mockedHost.accounts[a].storage[{}] = {0x01_bytes32};
     EXPECT_TRUE(host.account_exists(a));
 
     EXPECT_EQ(host.set_storage(a, {}, v), EVMC_STORAGE_MODIFIED);

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -90,7 +90,7 @@ TEST_F(example_vm, return_address)
 TEST_F(example_vm, counter_in_storage)
 {
     // Yul: sstore(0, add(sload(0), 1)) stop()
-    auto& storage_value = host.accounts[msg.recipient].storage[{}].value;
+    auto& storage_value = host.accounts[msg.recipient].storage[{}].current;
     storage_value = 0x00000000000000000000000000000000000000000000000000000000000000bb_bytes32;
     const auto r = execute_in_example_vm(10, "60016000540160005500");
     EXPECT_EQ(r.status_code, EVMC_SUCCESS);

--- a/test/unittests/mocked_host_test.cpp
+++ b/test/unittests/mocked_host_test.cpp
@@ -38,7 +38,7 @@ TEST(mocked_host, storage)
     EXPECT_EQ(host.set_storage(addr1, val1, val2), EVMC_STORAGE_ADDED);
     EXPECT_EQ(chost.accounts.count(addr1), 1u);
     EXPECT_EQ(host.accounts[addr1].storage.count(val1), 1u);
-    EXPECT_EQ(host.accounts[addr1].storage[val1].value, val2);
+    EXPECT_EQ(host.accounts[addr1].storage[val1].current, val2);
 
     auto& acc2 = host.accounts[addr2];
     EXPECT_EQ(chost.get_storage(addr2, val1), evmc::bytes32{});
@@ -52,21 +52,22 @@ TEST(mocked_host, storage)
     EXPECT_EQ(host.set_storage(addr2, val1, val3), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val3);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
+    EXPECT_NE(acc2.storage[val1].current, acc2.storage[val1].original);
     EXPECT_EQ(host.set_storage(addr2, val1, val1), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val1);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
     EXPECT_EQ(acc2.storage.size(), 1u);
-    EXPECT_TRUE(acc2.storage.find(val1)->second.dirty);
+    EXPECT_EQ(acc2.storage[val1].current, acc2.storage[val1].original);
 
     EXPECT_EQ(chost.get_storage(addr2, val3), evmc::bytes32{});
     acc2.storage[val3] = val2;
     EXPECT_EQ(chost.get_storage(addr2, val3), val2);
-    EXPECT_FALSE(acc2.storage.find(val3)->second.dirty);
+    EXPECT_EQ(acc2.storage.find(val3)->second.current, acc2.storage.find(val3)->second.original);
     EXPECT_EQ(host.set_storage(addr2, val3, val2), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val3), val2);
     EXPECT_EQ(host.set_storage(addr2, val3, val3), EVMC_STORAGE_MODIFIED);
     EXPECT_EQ(chost.get_storage(addr2, val3), val3);
-    acc2.storage[val3].dirty = false;
+    acc2.storage[val3].original = acc2.storage[val3].current;
     EXPECT_EQ(host.set_storage(addr2, val3, val1), EVMC_STORAGE_DELETED);
     EXPECT_EQ(chost.get_storage(addr2, val3), val1);
 }

--- a/test/unittests/mocked_host_test.cpp
+++ b/test/unittests/mocked_host_test.cpp
@@ -46,13 +46,13 @@ TEST(mocked_host, storage)
     EXPECT_EQ(host.set_storage(addr2, val1, val2), EVMC_STORAGE_ADDED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val2);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
-    EXPECT_EQ(host.set_storage(addr2, val1, val2), EVMC_STORAGE_UNCHANGED);
+    EXPECT_EQ(host.set_storage(addr2, val1, val2), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val2);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
-    EXPECT_EQ(host.set_storage(addr2, val1, val3), EVMC_STORAGE_MODIFIED_AGAIN);
+    EXPECT_EQ(host.set_storage(addr2, val1, val3), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val3);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
-    EXPECT_EQ(host.set_storage(addr2, val1, val1), EVMC_STORAGE_MODIFIED_AGAIN);
+    EXPECT_EQ(host.set_storage(addr2, val1, val1), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val1), val1);
     EXPECT_EQ(acc2.storage.count(val1), 1u);
     EXPECT_EQ(acc2.storage.size(), 1u);
@@ -62,7 +62,7 @@ TEST(mocked_host, storage)
     acc2.storage[val3] = val2;
     EXPECT_EQ(chost.get_storage(addr2, val3), val2);
     EXPECT_FALSE(acc2.storage.find(val3)->second.dirty);
-    EXPECT_EQ(host.set_storage(addr2, val3, val2), EVMC_STORAGE_UNCHANGED);
+    EXPECT_EQ(host.set_storage(addr2, val3, val2), EVMC_STORAGE_ASSIGNED);
     EXPECT_EQ(chost.get_storage(addr2, val3), val2);
     EXPECT_EQ(host.set_storage(addr2, val3, val3), EVMC_STORAGE_MODIFIED);
     EXPECT_EQ(chost.get_storage(addr2, val3), val3);


### PR DESCRIPTION
Expand the number of storage statuses to cover all possible EVM
behaviors. These provide enough information to VM to compute not only
gas costs but also refunds. Including legacy SSTORE costs before net
gas metering.