### PR TITLE
C++: Rename evmc::result → evmc::Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning].
 - The `evmc_message::destination` field has been renamed to `evmc_message::recipient`
   to clarify its purpose and match the naming from the Yellow Paper.
   [#616](https://github.com/ethereum/evmc/pull/616)
+- C++: The `evmc::result` has been renamed to `evmc::Result` for consistency 
+  with C++ types of similar kind.
+  [#665](https://github.com/ethereum/evmc/pull/665)
 - C++: The `HostContext` does not cache transaction context (`evmc_tx_context`) anymore.
   [#631](https://github.com/ethereum/evmc/pull/631)
 - Go: The `create2Salt` parameter has been removed from the `VM.Execute()`.

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -131,9 +131,9 @@ public:
         (void)beneficiary;
     }
 
-    evmc::result call(const evmc_message& msg) noexcept final
+    evmc::Result call(const evmc_message& msg) noexcept final
     {
-        return evmc::result{EVMC_REVERT, msg.gas, msg.input_data, msg.input_size};
+        return evmc::Result{EVMC_REVERT, msg.gas, msg.input_data, msg.input_size};
     }
 
     evmc_tx_context get_tx_context() const noexcept final { return tx_context; }

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -278,7 +278,7 @@ public:
     }
 
     /// Call/create other contract (EVMC host method).
-    result call(const evmc_message& msg) noexcept override
+    Result call(const evmc_message& msg) noexcept override
     {
         record_account_access(msg.recipient);
 
@@ -299,7 +299,7 @@ public:
                 call_msg.input_data = input_copy.data();
             }
         }
-        return result{call_result};
+        return Result{call_result};
     }
 
     /// Get transaction context (EVMC host method).

--- a/lib/tooling/run.cpp
+++ b/lib/tooling/run.cpp
@@ -24,7 +24,7 @@ auto bench(MockedHost& host,
            evmc_revision rev,
            const evmc_message& msg,
            bytes_view code,
-           const evmc::result& expected_result,
+           const evmc::Result& expected_result,
            std::ostream& out)
 {
     {

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -54,7 +54,7 @@ public:
                       const evmc::address& /*beneficiary*/) noexcept final
     {}
 
-    evmc::result call(const evmc_message& /*msg*/) noexcept final { return evmc::result{}; }
+    evmc::Result call(const evmc_message& /*msg*/) noexcept final { return evmc::Result{}; }
 
     evmc_tx_context get_tx_context() const noexcept final { return {}; }
 
@@ -457,11 +457,11 @@ TEST(cpp, result)
         };
         EXPECT_EQ(release_called, 0);
 
-        auto res1 = evmc::result{raw_result};
+        auto res1 = evmc::Result{raw_result};
         auto res2 = std::move(res1);
         EXPECT_EQ(release_called, 0);
 
-        auto f = [](evmc::result r) { EXPECT_EQ(r.output_data, &output); };
+        auto f = [](evmc::Result r) { EXPECT_EQ(r.output_data, &output); };
         f(std::move(res2));
 
         EXPECT_EQ(release_called, 1);
@@ -720,7 +720,7 @@ TEST(cpp, result_raii)
         raw_result.status_code = EVMC_INTERNAL_ERROR;
         raw_result.release = release_fn;
 
-        auto raii_result = evmc::result{raw_result};
+        auto raii_result = evmc::Result{raw_result};
         EXPECT_EQ(raii_result.status_code, EVMC_INTERNAL_ERROR);
         EXPECT_EQ(raii_result.gas_left, 0);
         raii_result.gas_left = -1;
@@ -740,7 +740,7 @@ TEST(cpp, result_raii)
         raw_result.status_code = EVMC_INTERNAL_ERROR;
         raw_result.release = release_fn;
 
-        auto raii_result = evmc::result{raw_result};
+        auto raii_result = evmc::Result{raw_result};
         EXPECT_EQ(raii_result.status_code, EVMC_INTERNAL_ERROR);
     }
     EXPECT_EQ(release_called, 1);
@@ -757,7 +757,7 @@ TEST(cpp, result_move)
         raw.gas_left = -1;
         raw.release = release_fn;
 
-        auto r0 = evmc::result{raw};
+        auto r0 = evmc::Result{raw};
         EXPECT_EQ(r0.gas_left, raw.gas_left);
 
         auto r1 = std::move(r0);
@@ -775,8 +775,8 @@ TEST(cpp, result_move)
         raw2.gas_left = 1;
         raw2.release = release_fn;
 
-        auto r1 = evmc::result{raw1};
-        auto r2 = evmc::result{raw2};
+        auto r1 = evmc::Result{raw1};
+        auto r2 = evmc::Result{raw2};
 
         r2 = std::move(r1);
     }
@@ -785,7 +785,7 @@ TEST(cpp, result_move)
 
 TEST(cpp, result_create_no_output)
 {
-    auto r = evmc::result{EVMC_REVERT, 1};
+    auto r = evmc::Result{EVMC_REVERT, 1};
     EXPECT_EQ(r.status_code, EVMC_REVERT);
     EXPECT_EQ(r.gas_left, 1);
     EXPECT_FALSE(r.output_data);
@@ -795,7 +795,7 @@ TEST(cpp, result_create_no_output)
 TEST(cpp, result_create)
 {
     const uint8_t output[] = {1, 2};
-    auto r = evmc::result{EVMC_FAILURE, -1, output, sizeof(output)};
+    auto r = evmc::Result{EVMC_FAILURE, -1, output, sizeof(output)};
     EXPECT_EQ(r.status_code, EVMC_FAILURE);
     EXPECT_EQ(r.gas_left, -1);
     ASSERT_TRUE(r.output_data);

--- a/test/unittests/example_vm_test.cpp
+++ b/test/unittests/example_vm_test.cpp
@@ -19,7 +19,7 @@ struct Output
 
     explicit Output(const char* output_hex) noexcept : bytes{evmc::from_hex(output_hex).value()} {}
 
-    friend bool operator==(const evmc::result& result, const Output& expected) noexcept
+    friend bool operator==(const evmc::Result& result, const Output& expected) noexcept
     {
         return expected.bytes.compare(0, evmc::bytes::npos, result.output_data,
                                       result.output_size) == 0;
@@ -41,7 +41,7 @@ protected:
         msg.recipient = 0xd00000000000000000000000000000000000000d_address;
     }
 
-    evmc::result execute_in_example_vm(int64_t gas,
+    evmc::Result execute_in_example_vm(int64_t gas,
                                        const char* code_hex,
                                        const char* input_hex = "")
     {


### PR DESCRIPTION
Rename the `evmc::result` to `evmc::Result` for consistency with C++ types of similar kind.
