### PR TITLE
Add gas refund to evmc_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ and this project adheres to [Semantic Versioning].
   [#634](https://github.com/ethereum/evmc/pull/634)
 - The Cancun EVM revision (anticipated after Shanghai)
   [#633](https://github.com/ethereum/evmc/pull/633)
+- The gas refund counter has been added to the `evmc_result`.
+  [#666](https://github.com/ethereum/evmc/pull/666)
 - The error code `EVMC_LOADER_UNSPECIFIED_ERROR` has been defined to provide
   a convenient way of initializing `evmc_loader_error_code` objects.
   [#617](https://github.com/ethereum/evmc/pull/617)
 - Support for Visual Studio 2022.
   [#619](https://github.com/ethereum/evmc/pull/619)
-- C++ types `evmc::address` and `evmc::bytes32` are convertible to `std::basic_string_view<uint8_t>`
-  .
+- C++ types `evmc::address` and `evmc::bytes32` are convertible to `std::basic_string_view<uint8_t>`.
   [#636](https://github.com/ethereum/evmc/pull/636)
 - Convenient constructors for C++ `evmc::result`.
   [#660](https://github.com/ethereum/evmc/pull/660)
@@ -41,7 +42,7 @@ and this project adheres to [Semantic Versioning].
 - The `evmc_message::destination` field has been renamed to `evmc_message::recipient`
   to clarify its purpose and match the naming from the Yellow Paper.
   [#616](https://github.com/ethereum/evmc/pull/616)
-- The `evmc_storage_status` has been extended to provide information about every possible case of 
+- The `evmc_storage_status` has been extended to provide information about every possible case of
   storage net gas metering ([EIP-2200](https://eips.ethereum.org/EIPS/eip-2200)).
   [#661](https://github.com/ethereum/evmc/pull/661)
 - The `selfdestruct` method returns the information if the given address

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -58,9 +58,10 @@ func (host *testHostContext) EmitLog(addr Address, topics []Hash, data []byte) {
 
 func (host *testHostContext) Call(kind CallKind,
 	recipient Address, sender Address, value Hash, input []byte, gas int64, depth int,
-	static bool, salt Hash, codeAddress Address) (output []byte, gasLeft int64, createAddr Address, err error) {
+	static bool, salt Hash, codeAddress Address) (output []byte, gasLeft int64, gasRefund int64,
+	createAddr Address, err error) {
 	output = []byte("output from testHostContext.Call()")
-	return output, gas, Address{}, nil
+	return output, gas, 0, Address{}, nil
 }
 
 func (host *testHostContext) AccessAccount(addr Address) AccessStatus {

--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -1,5 +1,5 @@
 # EVMC: Ethereum Client-VM Connector API.
-# Copyright 2019-2020 The EVMC Authors.
+# Copyright 2019 The EVMC Authors.
 # Licensed under the Apache License, Version 2.0.
 
 JAVA_HOME:=$(shell java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | sed 's/\s*java.home = //' | sed 's/\/jre//')

--- a/bindings/java/c/host.c
+++ b/bindings/java/c/host.c
@@ -42,7 +42,7 @@ static void CopyFromByteBuffer(JNIEnv* jenv, jobject src, void* dst, size_t size
     {
         jclass exception_class = (*jenv)->FindClass(jenv, "java/lang/IllegalArgumentException");
         assert(exception_class != NULL);
-        (*jenv)->ThrowNew(jenv, exception_class, "Unexpected length.");
+        (*jenv)->ThrowNew(jenv, exception_class, "Unexpected ByteBuffer length.");
     }
     memcpy(dst, ptr, size);
 }

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
@@ -58,7 +58,7 @@ class TestHostContext implements HostContext {
 
   @Override
   public ByteBuffer call(ByteBuffer msg) {
-    return ByteBuffer.allocateDirect(64).put(new byte[64]);
+    return ByteBuffer.allocateDirect(72).put(new byte[72]);
   }
 
   @Override

--- a/bindings/rust/evmc-declare-tests/src/lib.rs
+++ b/bindings/rust/evmc-declare-tests/src/lib.rs
@@ -35,6 +35,6 @@ impl EvmcVm for FooVM {
         _message: &ExecutionMessage,
         _context: Option<&mut ExecutionContext>,
     ) -> ExecutionResult {
-        ExecutionResult::success(1337, None)
+        ExecutionResult::success(1337, 21, None)
     }
 }

--- a/bindings/rust/evmc-declare/src/lib.rs
+++ b/bindings/rust/evmc-declare/src/lib.rs
@@ -22,7 +22,7 @@
 //!     }
 //!
 //!     fn execute(&self, revision: evmc_vm::ffi::evmc_revision, code: &[u8], message: &evmc_vm::ExecutionMessage, context: Option<&mut evmc_vm::ExecutionContext>) -> evmc_vm::ExecutionResult {
-//!             evmc_vm::ExecutionResult::success(1337, None)
+//!             evmc_vm::ExecutionResult::success(1337, 0, None)
 //!     }
 //! }
 //! ```
@@ -446,7 +446,7 @@ fn build_execute_fn(names: &VMNameSet) -> proc_macro2::TokenStream {
 
             let result = if result.is_err() {
                 // Consider a panic an internal error.
-                ::evmc_vm::ExecutionResult::new(::evmc_vm::ffi::evmc_status_code::EVMC_INTERNAL_ERROR, 0, None)
+                ::evmc_vm::ExecutionResult::new(::evmc_vm::ffi::evmc_status_code::EVMC_INTERNAL_ERROR, 0, 0, None)
             } else {
                 result.unwrap()
             };

--- a/bindings/rust/evmc-sys/src/lib.rs
+++ b/bindings/rust/evmc-sys/src/lib.rs
@@ -38,7 +38,6 @@ mod tests {
         // TODO: add other checks from test/unittests/test_helpers.cpp
         assert_eq!(size_of::<evmc_bytes32>(), 32);
         assert_eq!(size_of::<evmc_address>(), 20);
-        assert!(size_of::<evmc_result>() <= 64);
         assert!(size_of::<evmc_vm>() <= 64);
     }
 }

--- a/examples/example-rust-vm/src/lib.rs
+++ b/examples/example-rust-vm/src/lib.rs
@@ -76,6 +76,6 @@ impl EvmcVm for ExampleRustVM {
         _context.set_storage(message.recipient(), &storage_key, &storage_value);
 
         let ret = format!("{}", block_number).into_bytes();
-        ExecutionResult::success(message.gas() / 2, Some(&ret))
+        ExecutionResult::success(message.gas() / 2, 0, Some(&ret))
     }
 }

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -134,7 +134,7 @@ public:
 
     evmc::Result call(const evmc_message& msg) noexcept final
     {
-        return evmc::Result{EVMC_REVERT, msg.gas, msg.input_data, msg.input_size};
+        return evmc::Result{EVMC_REVERT, msg.gas, 0, msg.input_data, msg.input_size};
     }
 
     evmc_tx_context get_tx_context() const noexcept final { return tx_context; }

--- a/examples/example_vm/example_vm.cpp
+++ b/examples/example_vm/example_vm.cpp
@@ -181,15 +181,15 @@ evmc_result execute(evmc_vm* instance,
         // Check remaining gas, assume each instruction costs 1.
         gas_left -= 1;
         if (gas_left < 0)
-            return evmc_make_result(EVMC_OUT_OF_GAS, 0, nullptr, 0);
+            return evmc_make_result(EVMC_OUT_OF_GAS, 0, 0, nullptr, 0);
 
         switch (code[pc])
         {
         default:
-            return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+            return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, 0, nullptr, 0);
 
         case OP_STOP:
-            return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
+            return evmc_make_result(EVMC_SUCCESS, gas_left, 0, nullptr, 0);
 
         case OP_ADD:
         {
@@ -235,7 +235,7 @@ evmc_result execute(evmc_vm* instance,
             uint32_t index = to_uint32(stack.pop());
             evmc_uint256be value = stack.pop();
             if (!memory.store(index, value.bytes, sizeof(value)))
-                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+                return evmc_make_result(EVMC_FAILURE, 0, 0, nullptr, 0);
             break;
         }
 
@@ -329,7 +329,7 @@ evmc_result execute(evmc_vm* instance,
             uint8_t* call_output_ptr = memory.expand(call_output_offset, call_output_size);
 
             if (call_msg.input_data == nullptr || call_output_ptr == nullptr)
-                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+                return evmc_make_result(EVMC_FAILURE, 0, 0, nullptr, 0);
 
             evmc_result call_result = host->call(context, &call_msg);
 
@@ -351,28 +351,28 @@ evmc_result execute(evmc_vm* instance,
             uint32_t output_size = to_uint32(stack.pop());
             uint8_t* output_ptr = memory.expand(output_offset, output_size);
             if (output_ptr == nullptr)
-                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+                return evmc_make_result(EVMC_FAILURE, 0, 0, nullptr, 0);
 
-            return evmc_make_result(EVMC_SUCCESS, gas_left, output_ptr, output_size);
+            return evmc_make_result(EVMC_SUCCESS, gas_left, 0, output_ptr, output_size);
         }
 
         case OP_REVERT:
         {
             if (rev < EVMC_BYZANTIUM)
-                return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, nullptr, 0);
+                return evmc_make_result(EVMC_UNDEFINED_INSTRUCTION, 0, 0, nullptr, 0);
 
             uint32_t output_offset = to_uint32(stack.pop());
             uint32_t output_size = to_uint32(stack.pop());
             uint8_t* output_ptr = memory.expand(output_offset, output_size);
             if (output_ptr == nullptr)
-                return evmc_make_result(EVMC_FAILURE, 0, nullptr, 0);
+                return evmc_make_result(EVMC_FAILURE, 0, 0, nullptr, 0);
 
-            return evmc_make_result(EVMC_REVERT, gas_left, output_ptr, output_size);
+            return evmc_make_result(EVMC_REVERT, gas_left, 0, output_ptr, output_size);
         }
         }
     }
 
-    return evmc_make_result(EVMC_SUCCESS, gas_left, nullptr, 0);
+    return evmc_make_result(EVMC_SUCCESS, gas_left, 0, nullptr, 0);
 }
 
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -402,6 +402,14 @@ struct evmc_result
     int64_t gas_left;
 
     /**
+     * The refunded gas accumulated from this execution and its sub-calls.
+     *
+     * The transaction gas refund limit is not applied.
+     * If evmc_result::status_code is other than ::EVMC_SUCCESS the value MUST be 0.
+     */
+    int64_t gas_refund;
+
+    /**
      * The reference to output data.
      *
      *  The output contains data coming from RETURN opcode (iff evmc_result::code

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -345,33 +345,39 @@ public:
     ///
     /// @param _status_code  The status code.
     /// @param _gas_left     The amount of gas left.
+    /// @param _gas_refund   The amount of refunded gas.
     /// @param _output_data  The pointer to the output.
     /// @param _output_size  The output size.
     explicit Result(evmc_status_code _status_code,
                     int64_t _gas_left,
+                    int64_t _gas_refund,
                     const uint8_t* _output_data,
                     size_t _output_size) noexcept
-      : evmc_result{make_result(_status_code, _gas_left, _output_data, _output_size)}
+      : evmc_result{make_result(_status_code, _gas_left, _gas_refund, _output_data, _output_size)}
     {}
 
     /// Creates the result without output.
     ///
     /// @param _status_code  The status code.
     /// @param _gas_left     The amount of gas left.
+    /// @param _gas_refund   The amount of refunded gas.
     explicit Result(evmc_status_code _status_code = EVMC_INTERNAL_ERROR,
-                    int64_t _gas_left = 0) noexcept
-      : evmc_result{make_result(_status_code, _gas_left, nullptr, 0)}
+                    int64_t _gas_left = 0,
+                    int64_t _gas_refund = 0) noexcept
+      : evmc_result{make_result(_status_code, _gas_left, _gas_refund, nullptr, 0)}
     {}
 
     /// Creates the result of contract creation.
     ///
     /// @param _status_code     The status code.
     /// @param _gas_left        The amount of gas left.
+    /// @param _gas_refund      The amount of refunded gas.
     /// @param _create_address  The address of the possibly created account.
     explicit Result(evmc_status_code _status_code,
                     int64_t _gas_left,
+                    int64_t _gas_refund,
                     const evmc_address& _create_address) noexcept
-      : evmc_result{make_result(_status_code, _gas_left, nullptr, 0)}
+      : evmc_result{make_result(_status_code, _gas_left, _gas_refund, nullptr, 0)}
     {
         create_address = _create_address;
     }

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -333,6 +333,7 @@ class Result : private evmc_result
 public:
     using evmc_result::create_address;
     using evmc_result::gas_left;
+    using evmc_result::gas_refund;
     using evmc_result::output_data;
     using evmc_result::output_size;
     using evmc_result::status_code;

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -119,10 +119,12 @@ static void evmc_free_result_memory(const struct evmc_result* result)
 ///
 /// @param status_code  The status code.
 /// @param gas_left     The amount of gas left.
+/// @param gas_refund   The amount of refunded gas.
 /// @param output_data  The pointer to the output.
 /// @param output_size  The output size.
 static inline struct evmc_result evmc_make_result(enum evmc_status_code status_code,
                                                   int64_t gas_left,
+                                                  int64_t gas_refund,
                                                   const uint8_t* output_data,
                                                   size_t output_size)
 {
@@ -147,6 +149,7 @@ static inline struct evmc_result evmc_make_result(enum evmc_status_code status_c
 
     result.status_code = status_code;
     result.gas_left = gas_left;
+    result.gas_refund = gas_refund;
     return result;
 }
 

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -799,15 +799,17 @@ TEST(cpp, result_create_no_output)
 TEST(cpp, result_create)
 {
     const uint8_t output[] = {1, 2};
-    auto r = evmc::Result{EVMC_FAILURE, -1, output, sizeof(output)};
+    auto r = evmc::Result{EVMC_FAILURE, -1, -2, output, sizeof(output)};
     EXPECT_EQ(r.status_code, EVMC_FAILURE);
     EXPECT_EQ(r.gas_left, -1);
+    EXPECT_EQ(r.gas_refund, -2);
     ASSERT_TRUE(r.output_data);
     ASSERT_EQ(r.output_size, size_t{2});
     EXPECT_EQ(r.output_data[0], 1);
     EXPECT_EQ(r.output_data[1], 2);
 
-    auto c = evmc::make_result(r.status_code, r.gas_left, r.output_data, r.output_size);
+    auto c =
+        evmc::make_result(r.status_code, r.gas_left, r.gas_refund, r.output_data, r.output_size);
     EXPECT_EQ(c.status_code, r.status_code);
     EXPECT_EQ(c.gas_left, r.gas_left);
     ASSERT_EQ(c.output_size, r.output_size);

--- a/test/unittests/helpers_test.cpp
+++ b/test/unittests/helpers_test.cpp
@@ -10,7 +10,6 @@
 
 static_assert(sizeof(evmc_bytes32) == 32, "evmc_bytes32 is too big");
 static_assert(sizeof(evmc_address) == 20, "evmc_address is too big");
-static_assert(sizeof(evmc_result) <= 64, "evmc_result does not fit cache line");
 static_assert(sizeof(evmc_vm) <= 64, "evmc_vm does not fit cache line");
 static_assert(offsetof(evmc_message, value) % sizeof(size_t) == 0,
               "evmc_message.value not aligned");


### PR DESCRIPTION
Add `gas_refund` field to `evmc_result` and `evmc::Result`.

Closes #413.
Replaces #417