### PR TITLE
Make Result accessible via evmc_result reference

### DIFF
--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -414,6 +414,12 @@ public:
         return *this;
     }
 
+    /// Access the result object as a referenced to ::evmc_result.
+    evmc_result& raw() noexcept { return *this; }
+
+    /// Access the result object as a const referenced to ::evmc_result.
+    const evmc_result& raw() const noexcept { return *this; }
+
     /// Releases the ownership and returns the raw copy of evmc_result.
     ///
     /// This method drops the ownership of the result

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -973,3 +973,25 @@ TEST(cpp, revision_to_string_invalid)
         EXPECT_EQ(os.str(), "<unknown>");
     }
 }
+
+TEST(cpp, result_c_const_access)
+{
+    static constexpr auto get_status = [](const evmc_result& c_result) noexcept {
+        return c_result.status_code;
+    };
+
+    const evmc::Result r{EVMC_REVERT};
+    EXPECT_EQ(get_status(r.raw()), EVMC_REVERT);
+}
+
+TEST(cpp, result_c_nonconst_access)
+{
+    static constexpr auto set_status = [](evmc_result& c_result) noexcept {
+        c_result.status_code = EVMC_SUCCESS;
+    };
+
+    evmc::Result r;
+    EXPECT_EQ(r.status_code, EVMC_INTERNAL_ERROR);
+    set_status(r.raw());
+    EXPECT_EQ(r.status_code, EVMC_SUCCESS);
+}


### PR DESCRIPTION
With `.raw()` method the `evmc::Result` can be passed to functions that just observe `evmc_result` and don't care about ownership. Something like:
```
void on_result(const evmc_result& res) {
  // use res somehow
}

void blah() {
  evmc::Result res{EVMC_SUCCESS, 1000, 0};
  on_result(res.raw()); // fine after this PR
}
```