### PR TITLE
Add refund to execution result in Go binding

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -195,12 +195,18 @@ func (vm *VM) SetOption(name string, value string) (err error) {
 	return err
 }
 
-func (vm *VM) Execute(ctx HostContext, rev Revision,
-	kind CallKind, static bool, depth int, gas int64,
-	recipient Address, sender Address, input []byte, value Hash,
-	code []byte) (output []byte, gasLeft int64, err error) {
-	result, err := vm.Execute2(ctx, rev, kind, static, depth, gas, recipient, sender, input, value, code)
-	return result.Output, result.GasLeft, err
+type Parameters struct {
+	Context   HostContext
+	Revision  Revision
+	Kind      CallKind
+	Static    bool
+	Depth     int
+	Gas       int64
+	Recipient Address
+	Sender    Address
+	Input     []byte
+	Value     Hash
+	Code      []byte
 }
 
 type Result struct {
@@ -209,25 +215,23 @@ type Result struct {
 	GasRefund int64
 }
 
-func (vm *VM) Execute2(ctx HostContext, rev Revision,
-	kind CallKind, static bool, depth int, gas int64,
-	recipient Address, sender Address, input []byte, value Hash,
-	code []byte) (res Result, err error) {
+func (vm *VM) Execute(params Parameters) (res Result, err error) {
 
 	flags := C.uint32_t(0)
-	if static {
+	if params.Static {
 		flags |= C.EVMC_STATIC
 	}
 
-	ctxId := addHostContext(ctx)
+	ctxId := addHostContext(params.Context)
 	// FIXME: Clarify passing by pointer vs passing by value.
-	evmcRecipient := evmcAddress(recipient)
-	evmcSender := evmcAddress(sender)
-	evmcValue := evmcBytes32(value)
-	result := C.execute_wrapper(vm.handle, C.uintptr_t(ctxId), uint32(rev),
-		C.enum_evmc_call_kind(kind), flags, C.int32_t(depth), C.int64_t(gas),
-		&evmcRecipient, &evmcSender, bytesPtr(input), C.size_t(len(input)), &evmcValue,
-		bytesPtr(code), C.size_t(len(code)))
+	evmcRecipient := evmcAddress(params.Recipient)
+	evmcSender := evmcAddress(params.Sender)
+	evmcValue := evmcBytes32(params.Value)
+	result := C.execute_wrapper(vm.handle, C.uintptr_t(ctxId),
+		uint32(params.Revision), C.enum_evmc_call_kind(params.Kind), flags,
+		C.int32_t(params.Depth), C.int64_t(params.Gas), &evmcRecipient,
+		&evmcSender, bytesPtr(params.Input), C.size_t(len(params.Input)),
+		&evmcValue, bytesPtr(params.Code), C.size_t(len(params.Code)))
 	removeHostContext(ctxId)
 
 	res.Output = C.GoBytes(unsafe.Pointer(result.output_data), C.int(result.output_size))

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -45,12 +45,9 @@ func TestExecuteEmptyCode(t *testing.T) {
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
-	result, err := vm.Execute(Parameters{
-		Revision: Byzantium,
-		Kind:     Call,
-		Depth:    1,
-		Gas:      999,
-	})
+	addr := Address{}
+	h := Hash{}
+	result, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
 
 	if !bytes.Equal(result.Output, []byte("")) {
 		t.Errorf("execution unexpected output: %x", result.Output)

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -49,11 +49,33 @@ func TestExecuteEmptyCode(t *testing.T) {
 	h := Hash{}
 	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
 
-	if bytes.Compare(output, []byte("")) != 0 {
+	if !bytes.Equal(output, []byte("")) {
 		t.Errorf("execution unexpected output: %x", output)
 	}
 	if gasLeft != 999 {
 		t.Errorf("execution gas left is incorrect: %d", gasLeft)
+	}
+	if err != nil {
+		t.Errorf("execution returned unexpected error: %v", err)
+	}
+}
+
+func TestExecuteEmptyCode2(t *testing.T) {
+	vm, _ := Load(modulePath)
+	defer vm.Destroy()
+
+	addr := Address{}
+	h := Hash{}
+	result, err := vm.Execute2(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
+
+	if !bytes.Equal(result.Output, []byte("")) {
+		t.Errorf("execution unexpected output: %x", result.Output)
+	}
+	if result.GasLeft != 999 {
+		t.Errorf("execution gas left is incorrect: %d", result.GasLeft)
+	}
+	if result.GasRefund != 0 {
+		t.Errorf("execution gas refund is incorrect: %d", result.GasRefund)
 	}
 	if err != nil {
 		t.Errorf("execution returned unexpected error: %v", err)

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -45,28 +45,12 @@ func TestExecuteEmptyCode(t *testing.T) {
 	vm, _ := Load(modulePath)
 	defer vm.Destroy()
 
-	addr := Address{}
-	h := Hash{}
-	output, gasLeft, err := vm.Execute(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
-
-	if !bytes.Equal(output, []byte("")) {
-		t.Errorf("execution unexpected output: %x", output)
-	}
-	if gasLeft != 999 {
-		t.Errorf("execution gas left is incorrect: %d", gasLeft)
-	}
-	if err != nil {
-		t.Errorf("execution returned unexpected error: %v", err)
-	}
-}
-
-func TestExecuteEmptyCode2(t *testing.T) {
-	vm, _ := Load(modulePath)
-	defer vm.Destroy()
-
-	addr := Address{}
-	h := Hash{}
-	result, err := vm.Execute2(nil, Byzantium, Call, false, 1, 999, addr, addr, nil, h, nil)
+	result, err := vm.Execute(Parameters{
+		Revision: Byzantium,
+		Kind:     Call,
+		Depth:    1,
+		Gas:      999,
+	})
 
 	if !bytes.Equal(result.Output, []byte("")) {
 		t.Errorf("execution unexpected output: %x", result.Output)

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -80,14 +80,9 @@ func TestGetBlockNumberFromTxContext(t *testing.T) {
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-	result, err := vm.Execute(Parameters{
-		Context:  host,
-		Revision: Byzantium,
-		Kind:     Call,
-		Depth:    1,
-		Gas:      100,
-		Code:     code,
-	})
+	addr := Address{}
+	h := Hash{}
+	result, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
 	output := result.Output
 	gasLeft := result.GasLeft
 
@@ -116,15 +111,9 @@ func TestCall(t *testing.T) {
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-
-	result, err := vm.Execute(Parameters{
-		Context:  host,
-		Revision: Byzantium,
-		Kind:     Call,
-		Depth:    1,
-		Gas:      100,
-		Code:     code,
-	})
+	addr := Address{}
+	h := Hash{}
+	result, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
 	output := result.Output
 	gasLeft := result.GasLeft
 

--- a/bindings/go/evmc/host_test.go
+++ b/bindings/go/evmc/host_test.go
@@ -80,9 +80,16 @@ func TestGetBlockNumberFromTxContext(t *testing.T) {
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-	addr := Address{}
-	h := Hash{}
-	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
+	result, err := vm.Execute(Parameters{
+		Context:  host,
+		Revision: Byzantium,
+		Kind:     Call,
+		Depth:    1,
+		Gas:      100,
+		Code:     code,
+	})
+	output := result.Output
+	gasLeft := result.GasLeft
 
 	if len(output) != 32 {
 		t.Errorf("unexpected output size: %d", len(output))
@@ -90,7 +97,7 @@ func TestGetBlockNumberFromTxContext(t *testing.T) {
 
 	// Should return value 42 (0x2a) as defined in GetTxContext().
 	expectedOutput := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x2a")
-	if bytes.Compare(output, expectedOutput) != 0 {
+	if !bytes.Equal(output, expectedOutput) {
 		t.Errorf("execution unexpected output: %x", output)
 	}
 	if gasLeft != 94 {
@@ -109,14 +116,22 @@ func TestCall(t *testing.T) {
 	defer vm.Destroy()
 
 	host := &testHostContext{}
-	addr := Address{}
-	h := Hash{}
-	output, gasLeft, err := vm.Execute(host, Byzantium, Call, false, 1, 100, addr, addr, nil, h, code)
+
+	result, err := vm.Execute(Parameters{
+		Context:  host,
+		Revision: Byzantium,
+		Kind:     Call,
+		Depth:    1,
+		Gas:      100,
+		Code:     code,
+	})
+	output := result.Output
+	gasLeft := result.GasLeft
 
 	if len(output) != 34 {
 		t.Errorf("execution unexpected output length: %d", len(output))
 	}
-	if bytes.Compare(output, []byte("output from testHostContext.Call()")) != 0 {
+	if !bytes.Equal(output, []byte("output from testHostContext.Call()")) {
 		t.Errorf("execution unexpected output: %s", output)
 	}
 	if gasLeft != 89 {


### PR DESCRIPTION
This PR modifies the `Execute()` function from the Go bindings to return a `Result` struct instead of a list of result values to support the retrieval of the amount of refunded gas. This information is available in [evmc.h](https://github.com/ethereum/evmc/blob/v10.1.0/include/evmc/evmc.h)'s [evmc_result](https://github.com/ethereum/evmc/blob/v10.1.0/include/evmc/evmc.h#L404-L410), but was not exposed in the Go binding so far.