### PR TITLE
Extend tx_context with EIP-4844 blob hashes

### DIFF
--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -181,6 +181,8 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 		evmcBytes32(txContext.PrevRandao),
 		evmcBytes32(txContext.ChainID),
 		evmcBytes32(txContext.BaseFee),
+		nil, // TODO: Add support for blob hashes.
+		0,
 	}
 }
 

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
@@ -63,7 +63,7 @@ class TestHostContext implements HostContext {
 
   @Override
   public ByteBuffer getTxContext() {
-    return ByteBuffer.allocateDirect(192).put(new byte[192]);
+    return ByteBuffer.allocateDirect(208).put(new byte[208]);
   }
 
   @Override

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -102,6 +102,8 @@ mod tests {
             block_prev_randao: Uint256::default(),
             chain_id: Uint256::default(),
             block_base_fee: Uint256::default(),
+            blob_hashes: std::ptr::null(),
+            blob_hashes_count: 0,
         }
     }
 

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -806,6 +806,8 @@ mod tests {
             block_prev_randao: Uint256 { bytes: [0xaa; 32] },
             chain_id: Uint256::default(),
             block_base_fee: Uint256::default(),
+            blob_hashes: std::ptr::null(),
+            blob_hashes_count: 0,
         }
     }
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -202,6 +202,8 @@ struct evmc_tx_context
     evmc_uint256be block_prev_randao; /**< The block previous RANDAO (EIP-4399). */
     evmc_uint256be chain_id;          /**< The blockchain's ChainID. */
     evmc_uint256be block_base_fee;    /**< The block base fee per gas (EIP-1559, EIP-3198). */
+    const evmc_bytes32* blob_hashes;  /**< The array of blob hashes (EIP-4844). */
+    size_t blob_hashes_count;         /**< The number of blob hashes (EIP-4844). */
 };
 
 /**


### PR DESCRIPTION
Extend `evmc_tx_context` with the reference to the array of blob hashes from EIP-4844.