### PR TITLE
Add transient storage support (EIP-1153)

### DIFF
--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -151,6 +151,8 @@ mod tests {
             emit_log: None,
             access_account: None,
             access_storage: None,
+            get_transient_storage: None,
+            set_transient_storage: None,
         };
         let host_context = std::ptr::null_mut();
 

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -864,6 +864,8 @@ mod tests {
             emit_log: None,
             access_account: None,
             access_storage: None,
+            get_transient_storage: None,
+            set_transient_storage: None,
         }
     }
 

--- a/examples/example_host.cpp
+++ b/examples/example_host.cpp
@@ -24,6 +24,7 @@ struct account
     evmc::uint256be balance = {};
     std::vector<uint8_t> code;
     std::map<evmc::bytes32, evmc::bytes32> storage;
+    std::map<evmc::bytes32, evmc::bytes32> transient_storage;
 
     virtual evmc::bytes32 code_hash() const
     {
@@ -174,6 +175,26 @@ public:
         (void)addr;
         (void)key;
         return EVMC_ACCESS_COLD;
+    }
+
+    evmc::bytes32 get_transient_storage(const evmc::address& addr,
+                                        const evmc::bytes32& key) const noexcept override
+    {
+        const auto account_iter = accounts.find(addr);
+        if (account_iter == accounts.end())
+            return {};
+
+        const auto transient_storage_iter = account_iter->second.transient_storage.find(key);
+        if (transient_storage_iter != account_iter->second.transient_storage.end())
+            return transient_storage_iter->second;
+        return {};
+    }
+
+    void set_transient_storage(const evmc::address& addr,
+                               const evmc::bytes32& key,
+                               const evmc::bytes32& value) noexcept override
+    {
+        accounts[addr].transient_storage[key] = value;
     }
 };
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -505,6 +505,22 @@ typedef evmc_bytes32 (*evmc_get_storage_fn)(struct evmc_host_context* context,
                                             const evmc_address* address,
                                             const evmc_bytes32* key);
 
+/**
+ * Get transient storage callback function.
+ *
+ * This callback function is used by a VM to query
+ * the given account transient storage (EIP-1153) entry.
+ *
+ * @param context  The Host execution context.
+ * @param address  The address of the account.
+ * @param key      The index of the account's transient storage entry.
+ * @return         The transient storage value at the given storage key or null bytes
+ *                 if the account does not exist.
+ */
+typedef evmc_bytes32 (*evmc_get_transient_storage_fn)(struct evmc_host_context* context,
+                                                      const evmc_address* address,
+                                                      const evmc_bytes32* key);
+
 
 /**
  * The effect of an attempt to modify a contract storage item.
@@ -621,6 +637,25 @@ typedef enum evmc_storage_status (*evmc_set_storage_fn)(struct evmc_host_context
                                                         const evmc_address* address,
                                                         const evmc_bytes32* key,
                                                         const evmc_bytes32* value);
+
+/**
+ * Set transient storage callback function.
+ *
+ * This callback function is used by a VM to update
+ * the given account's transient storage (EIP-1153) entry.
+ * The VM MUST make sure that the account exists. This requirement is only a formality because
+ * VM implementations only modify storage of the account of the current execution context
+ * (i.e. referenced by evmc_message::recipient).
+ *
+ * @param context  The pointer to the Host execution context.
+ * @param address  The address of the account.
+ * @param key      The index of the transient storage entry.
+ * @param value    The value to be stored.
+ */
+typedef void (*evmc_set_transient_storage_fn)(struct evmc_host_context* context,
+                                              const evmc_address* address,
+                                              const evmc_bytes32* key,
+                                              const evmc_bytes32* value);
 
 /**
  * Get balance callback function.
@@ -827,6 +862,12 @@ struct evmc_host_interface
 
     /** Access storage callback function. */
     evmc_access_storage_fn access_storage;
+
+    /** Get transient storage callback function. */
+    evmc_get_transient_storage_fn get_transient_storage;
+
+    /** Set transient storage callback function. */
+    evmc_set_transient_storage_fn set_transient_storage;
 };
 
 

--- a/include/evmc/evmc.hpp
+++ b/include/evmc/evmc.hpp
@@ -493,6 +493,15 @@ public:
 
     /// @copydoc evmc_host_interface::access_storage
     virtual evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept = 0;
+
+    /// @copydoc evmc_host_interface::get_transient_storage
+    virtual bytes32 get_transient_storage(const address& addr,
+                                          const bytes32& key) const noexcept = 0;
+
+    /// @copydoc evmc_host_interface::set_transient_storage
+    virtual void set_transient_storage(const address& addr,
+                                       const bytes32& key,
+                                       const bytes32& value) noexcept = 0;
 };
 
 
@@ -590,6 +599,18 @@ public:
     evmc_access_status access_storage(const address& address, const bytes32& key) noexcept final
     {
         return host->access_storage(context, &address, &key);
+    }
+
+    bytes32 get_transient_storage(const address& address, const bytes32& key) const noexcept final
+    {
+        return host->get_transient_storage(context, &address, &key);
+    }
+
+    void set_transient_storage(const address& address,
+                               const bytes32& key,
+                               const bytes32& value) noexcept final
+    {
+        host->set_transient_storage(context, &address, &key, &value);
     }
 };
 
@@ -844,18 +865,42 @@ inline evmc_access_status access_storage(evmc_host_context* h,
 {
     return Host::from_context(h)->access_storage(*addr, *key);
 }
+
+inline evmc_bytes32 get_transient_storage(evmc_host_context* h,
+                                          const evmc_address* addr,
+                                          const evmc_bytes32* key) noexcept
+{
+    return Host::from_context(h)->get_transient_storage(*addr, *key);
+}
+
+inline void set_transient_storage(evmc_host_context* h,
+                                  const evmc_address* addr,
+                                  const evmc_bytes32* key,
+                                  const evmc_bytes32* value) noexcept
+{
+    Host::from_context(h)->set_transient_storage(*addr, *key, *value);
+}
 }  // namespace internal
 
 inline const evmc_host_interface& Host::get_interface() noexcept
 {
     static constexpr evmc_host_interface interface = {
-        ::evmc::internal::account_exists, ::evmc::internal::get_storage,
-        ::evmc::internal::set_storage,    ::evmc::internal::get_balance,
-        ::evmc::internal::get_code_size,  ::evmc::internal::get_code_hash,
-        ::evmc::internal::copy_code,      ::evmc::internal::selfdestruct,
-        ::evmc::internal::call,           ::evmc::internal::get_tx_context,
-        ::evmc::internal::get_block_hash, ::evmc::internal::emit_log,
-        ::evmc::internal::access_account, ::evmc::internal::access_storage,
+        ::evmc::internal::account_exists,
+        ::evmc::internal::get_storage,
+        ::evmc::internal::set_storage,
+        ::evmc::internal::get_balance,
+        ::evmc::internal::get_code_size,
+        ::evmc::internal::get_code_hash,
+        ::evmc::internal::copy_code,
+        ::evmc::internal::selfdestruct,
+        ::evmc::internal::call,
+        ::evmc::internal::get_tx_context,
+        ::evmc::internal::get_block_hash,
+        ::evmc::internal::emit_log,
+        ::evmc::internal::access_account,
+        ::evmc::internal::access_storage,
+        ::evmc::internal::get_transient_storage,
+        ::evmc::internal::set_transient_storage,
     };
     return interface;
 }

--- a/include/evmc/mocked_host.hpp
+++ b/include/evmc/mocked_host.hpp
@@ -62,6 +62,9 @@ struct MockedAccount
     /// The account storage map.
     std::unordered_map<bytes32, StorageValue> storage;
 
+    /// The account transient storage.
+    std::unordered_map<bytes32, bytes32> transient_storage;
+
     /// Helper method for setting balance by numeric type.
     void set_balance(uint64_t x) noexcept
     {
@@ -466,8 +469,7 @@ public:
     ///
     /// @param addr  The account address.
     /// @param key   The account's storage key.
-    /// @return      The ::EVMC_ACCESS_WARM if the storage key has been accessed
-    /// before,
+    /// @return      The ::EVMC_ACCESS_WARM if the storage key has been accessed before,
     ///              the ::EVMC_ACCESS_COLD otherwise.
     evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept override
     {
@@ -475,6 +477,38 @@ public:
         const auto access_status = value.access_status;
         value.access_status = EVMC_ACCESS_WARM;
         return access_status;
+    }
+
+    /// Get account's transient storage.
+    ///
+    /// @param addr  The account address.
+    /// @param key   The account's transient storage key.
+    /// @return      The transient storage value. Null value in case the account does not exist.
+    bytes32 get_transient_storage(const address& addr, const bytes32& key) const noexcept override
+    {
+        record_account_access(addr);
+
+        const auto account_iter = accounts.find(addr);
+        if (account_iter == accounts.end())
+            return {};
+
+        const auto storage_iter = account_iter->second.transient_storage.find(key);
+        if (storage_iter != account_iter->second.transient_storage.end())
+            return storage_iter->second;
+        return {};
+    }
+
+    /// Set account's transient storage.
+    ///
+    /// @param addr   The account address.
+    /// @param key    The account's transient storage key.
+    /// @param value  The value to be stored.
+    void set_transient_storage(const address& addr,
+                               const bytes32& key,
+                               const bytes32& value) noexcept override
+    {
+        record_account_access(addr);
+        accounts[addr].transient_storage[key] = value;
     }
 };
 }  // namespace evmc

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -81,6 +81,17 @@ public:
     {
         return EVMC_ACCESS_COLD;
     }
+
+    evmc::bytes32 get_transient_storage(const evmc::address& /*addr*/,
+                                        const evmc::bytes32& /*key*/) const noexcept override
+    {
+        return {};
+    }
+
+    void set_transient_storage(const evmc::address& /*addr*/,
+                               const evmc::bytes32& /*key*/,
+                               const evmc::bytes32& /*value*/) noexcept override
+    {}
 };
 
 TEST(cpp, address)
@@ -661,6 +672,14 @@ TEST(cpp, host)
     EXPECT_EQ(host.get_block_hash(0), evmc::bytes32{});
 
     host.emit_log(a, nullptr, 0, nullptr, 0);
+    ASSERT_EQ(mockedHost.recorded_logs.size(), 1);
+    EXPECT_EQ(mockedHost.recorded_logs[0].creator, a);
+
+    EXPECT_EQ(host.access_storage(a, {}), EVMC_ACCESS_COLD);
+    EXPECT_EQ(host.access_storage(a, {}), EVMC_ACCESS_WARM);
+
+    host.set_transient_storage(a, 0x01_bytes32, v);
+    EXPECT_EQ(host.get_transient_storage(a, 0x01_bytes32), v);
 }
 
 TEST(cpp, host_call)

--- a/test/unittests/mocked_host_test.cpp
+++ b/test/unittests/mocked_host_test.cpp
@@ -131,3 +131,23 @@ TEST(mocked_host, selfdestruct)
     EXPECT_EQ(host.recorded_selfdestructs[0xdead02_address][0], 0xbece01_address);
     EXPECT_EQ(host.recorded_selfdestructs[0xdead02_address][1], 0xbece01_address);
 }
+
+TEST(mocked_host, transient_storage)
+{
+    evmc::MockedHost host;
+
+    // Get from non-existing account.
+    EXPECT_EQ(host.get_transient_storage(0xa1_address, 0xc1_bytes32), 0x00_bytes32);
+    EXPECT_EQ(host.accounts.size(), 0);
+
+    host.set_transient_storage(0xa1_address, 0xc1_bytes32, 0x01_bytes32);
+    EXPECT_EQ(host.accounts[0xa1_address].transient_storage[0xc1_bytes32], 0x01_bytes32);
+    EXPECT_EQ(host.get_transient_storage(0xa1_address, 0xc1_bytes32), 0x01_bytes32);
+
+    host.set_transient_storage(0xa1_address, 0xc1_bytes32, 0x00_bytes32);
+    EXPECT_EQ(host.accounts[0xa1_address].transient_storage[0xc1_bytes32], 0x00_bytes32);
+    EXPECT_EQ(host.get_transient_storage(0xa1_address, 0xc1_bytes32), 0x00_bytes32);
+
+    // Get non-existing key of existing account.
+    EXPECT_EQ(host.get_transient_storage(0xa1_address, 0xc2_bytes32), 0x00_bytes32);
+}


### PR DESCRIPTION
Add EVMC Host API for accessing and modifying transient storage (EIP-1153).
https://eips.ethereum.org/EIPS/eip-1153

Extend EVMC Host API with methods

- `get_transient_storage()`
- `set_transient_storage()`

to expose transaction-level transient storage (EIP-1153) to VM.