### PR TITLE
cmake: Fix evmc_add_vm_test() not working in cross-compilation

### DIFF
--- a/cmake/EVMC.cmake
+++ b/cmake/EVMC.cmake
@@ -14,5 +14,5 @@ function(evmc_add_vm_test)
     endif()
 
     cmake_parse_arguments("" "" NAME;TARGET "" ${ARGN})
-    add_test(NAME ${_NAME} COMMAND $<TARGET_FILE:evmc::evmc-vmtester> $<TARGET_FILE:${_TARGET}>)
+    add_test(NAME ${_NAME} COMMAND evmc::evmc-vmtester $<TARGET_FILE:${_TARGET}>)
 endfunction()


### PR DESCRIPTION
In add_test() use the `evmc::evmc-vmtester` CMake target name directly to make it work with `CROSSCOMPILING_EMULATOR`.