### PR TITLE
Extended `tx_context` with "blob base fee"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning].
 
 ### Added
 
-- Extended `tx_context` with [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) blob hashes
+- Extended `tx_context` with the [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) blob hashes
   [#691](https://github.com/ethereum/evmc/pull/691)
+- Extended `tx_context` with the [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) "blob base fee"
+  for the `BLOBBASEFEE` EVM instruction.
+  [#696](https://github.com/ethereum/evmc/pull/696)
 - Added [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) transient storage support
   [#693](https://github.com/ethereum/evmc/pull/693)
 

--- a/bindings/go/evmc/host.go
+++ b/bindings/go/evmc/host.go
@@ -72,15 +72,16 @@ func goByteSlice(data *C.uint8_t, size C.size_t) []byte {
 
 // TxContext contains information about current transaction and block.
 type TxContext struct {
-	GasPrice   Hash
-	Origin     Address
-	Coinbase   Address
-	Number     int64
-	Timestamp  int64
-	GasLimit   int64
-	PrevRandao Hash
-	ChainID    Hash
-	BaseFee    Hash
+	GasPrice    Hash
+	Origin      Address
+	Coinbase    Address
+	Number      int64
+	Timestamp   int64
+	GasLimit    int64
+	PrevRandao  Hash
+	ChainID     Hash
+	BaseFee     Hash
+	BlobBaseFee Hash
 }
 
 type HostContext interface {
@@ -181,6 +182,7 @@ func getTxContext(pCtx unsafe.Pointer) C.struct_evmc_tx_context {
 		evmcBytes32(txContext.PrevRandao),
 		evmcBytes32(txContext.ChainID),
 		evmcBytes32(txContext.BaseFee),
+		evmcBytes32(txContext.BlobBaseFee),
 		nil, // TODO: Add support for blob hashes.
 		0,
 	}

--- a/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
+++ b/bindings/java/java/src/test/java/org/ethereum/evmc/TestHostContext.java
@@ -63,7 +63,7 @@ class TestHostContext implements HostContext {
 
   @Override
   public ByteBuffer getTxContext() {
-    return ByteBuffer.allocateDirect(208).put(new byte[208]);
+    return ByteBuffer.allocateDirect(240).put(new byte[240]);
   }
 
   @Override

--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -102,6 +102,7 @@ mod tests {
             block_prev_randao: Uint256::default(),
             chain_id: Uint256::default(),
             block_base_fee: Uint256::default(),
+            blob_base_fee: Uint256::default(),
             blob_hashes: std::ptr::null(),
             blob_hashes_count: 0,
         }

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -806,6 +806,7 @@ mod tests {
             block_prev_randao: Uint256 { bytes: [0xaa; 32] },
             chain_id: Uint256::default(),
             block_base_fee: Uint256::default(),
+            blob_base_fee: Uint256::default(),
             blob_hashes: std::ptr::null(),
             blob_hashes_count: 0,
         }

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -202,6 +202,7 @@ struct evmc_tx_context
     evmc_uint256be block_prev_randao; /**< The block previous RANDAO (EIP-4399). */
     evmc_uint256be chain_id;          /**< The blockchain's ChainID. */
     evmc_uint256be block_base_fee;    /**< The block base fee per gas (EIP-1559, EIP-3198). */
+    evmc_uint256be blob_base_fee;     /**< The blob base fee (EIP-7516). */
     const evmc_bytes32* blob_hashes;  /**< The array of blob hashes (EIP-4844). */
     size_t blob_hashes_count;         /**< The number of blob hashes (EIP-4844). */
 };


### PR DESCRIPTION
Extended `tx_context` with the [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) "blob base fee" for the `BLOBBASEFEE` EVM instruction.