### PR TITLE
Fix rust bindings generation

### DIFF
--- a/bindings/rust/evmc-sys/Cargo.toml
+++ b/bindings/rust/evmc-sys/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["external-ffi-bindings"]
 edition = "2018"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.69.4"

--- a/bindings/rust/evmc-sys/build.rs
+++ b/bindings/rust/evmc-sys/build.rs
@@ -14,7 +14,7 @@ fn gen_bindings() {
         // do not generate an empty enum for EVMC_ABI_VERSION
         .constified_enum("")
         // generate Rust enums for each evmc enum
-        .rustified_enum("*")
+        .rustified_enum(".*")
         // force deriving the Hash trait on basic types (address, bytes32)
         .derive_hash(true)
         // force deriving the PratialEq trait on basic types (address, bytes32)


### PR DESCRIPTION
# Description

This PR fixes two issues with the rust bindings:
- Constant `EMVC_ABI_VERSION` is not exported, caused by an outdated `bindgen`
- Enums are not properly rustified, due to invalid configuration.

# Testing

I've run `cargo test` for the whole workspace and `cargo build` for the `example-rust-vm`.