### PR TITLE
Remove outdated references to external tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Please visit the [documentation].
 
 * **evmc run** ([tools/evmc]) — executes bytecode in any EVMC-compatible VM implementation.
 * **evmc-vmtester** ([tools/vmtester]) — can test any EVM implementation for compatibility with EVMC.
-* **evm-test** ([evmone → test/unittests]) — allows running the collection of [evmone]'s unit tests on any EVMC-compatible EVM implementation.
-* **evmone-fuzzer** ([evmone → test/fuzzer]) — differential fuzzer for EVMC-compatible EVM implementations. 
 
 
 ## Related projects
@@ -103,8 +101,6 @@ Licensed under the [Apache License, Version 2.0].
 [ewasm]: https://github.com/ewasm/design
 [evmjit]: https://github.com/ethereum/evmjit
 [evmone]: https://github.com/ethereum/evmone
-[evmone → test/fuzzer]: https://github.com/ethereum/evmone/tree/master/test/fuzzer
-[evmone → test/unittests]: https://github.com/ethereum/evmone/tree/master/test/unittests
 [Hera]: https://github.com/ewasm/hera
 [Hera.rs]: https://github.com/ewasm/hera.rs
 [Daytona]: https://github.com/axic/daytona


### PR DESCRIPTION
evmone's tests no longer support testing other EVMC-compatible EVM implementations.

`evm-test` dropped support for external EVM implementations [in 2020](https://github.com/ethereum/evmone/pull/262/files#diff-164433c97916ccb25c2acf05bac88cb9a9be3e5fdc737f0541cd838444536a94R27).

`evmone-fuzzer` doesn't support fuzzing external EVM implemenations. It looks like they used to support fuzzing Aleth, but they dropped support for that [in 2022](https://github.com/ethereum/evmone/pull/453). The list of EVM targets is hardcoded to [just evmone](https://github.com/ethereum/evmone/blob/7bd7596c2754229f37344e10cdd49d638391f90f/test/fuzzer/fuzzer.cpp#L61).