### PR TITLE
fix: get code hash func name

### DIFF
--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -299,7 +299,7 @@ impl<'a> ExecutionContext<'a> {
     /// Get code hash of an account.
     pub fn get_code_hash(&self, address: &Address) -> Bytes32 {
         unsafe {
-            assert!((*self.host).get_code_size.is_some());
+            assert!((*self.host).get_code_hash.is_some());
             (*self.host).get_code_hash.unwrap()(self.context, address as *const Address)
         }
     }


### PR DESCRIPTION
# Background

Hello community, I am working on a project called [Dora](https://github.com/dp-labs/dora) written in Rust Integrated into EVMC Rust Bindings, I found that the `get_code_hash` function name typo, so I opened the PR to fix it.