### PR TITLE
Add EXPERIMENTAL revision

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -112,6 +112,7 @@ const (
 	Cancun               Revision = C.EVMC_CANCUN
 	Prague               Revision = C.EVMC_PRAGUE
 	Osaka                Revision = C.EVMC_OSAKA
+	Experimental         Revision = C.EVMC_EXPERIMENTAL
 	MaxRevision          Revision = C.EVMC_MAX_REVISION
 	LatestStableRevision Revision = C.EVMC_LATEST_STABLE_REVISION
 )

--- a/bindings/go/evmc/evmc_test.go
+++ b/bindings/go/evmc/evmc_test.go
@@ -64,7 +64,7 @@ func TestExecuteEmptyCode(t *testing.T) {
 }
 
 func TestRevision(t *testing.T) {
-	if MaxRevision != Osaka {
+	if MaxRevision != Experimental {
 		t.Errorf("missing constant for revision %d", MaxRevision)
 	}
 	if LatestStableRevision != Cancun {

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -1034,21 +1034,27 @@ enum evmc_revision
     EVMC_CANCUN = 12,
 
     /**
-     * The Prague revision.
+     * The Prague / Pectra revision.
      *
-     * The future next revision after Cancun.
+     * https://eips.ethereum.org/EIPS/eip-7600
      */
     EVMC_PRAGUE = 13,
 
     /**
-     * The Osaka revision.
+     * The Osaka / Fusaka revision.
      *
-     * The future next revision after Prague.
+     * https://eips.ethereum.org/EIPS/eip-7607
      */
     EVMC_OSAKA = 14,
 
+    /**
+     * The unspecified EVM revision used for EVM implementations to expose
+     * experimental features.
+     */
+    EVMC_EXPERIMENTAL = 15,
+
     /** The maximum EVM revision supported. */
-    EVMC_MAX_REVISION = EVMC_OSAKA,
+    EVMC_MAX_REVISION = EVMC_EXPERIMENTAL,
 
     /**
      * The latest known EVM revision with finalized specification.

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -303,6 +303,8 @@ static inline const char* evmc_revision_to_string(enum evmc_revision rev)
         return "Prague";
     case EVMC_OSAKA:
         return "Osaka";
+    case EVMC_EXPERIMENTAL:
+        return "Experimental";
     }
     return "<unknown>";
 }

--- a/lib/instructions/instruction_metrics.c
+++ b/lib/instructions/instruction_metrics.c
@@ -3146,6 +3146,7 @@ const struct evmc_instruction_metrics* evmc_get_instruction_metrics_table(
 {
     switch (revision)
     {
+    case EVMC_EXPERIMENTAL:
     case EVMC_OSAKA:
         return osaka_metrics;
     case EVMC_PRAGUE:

--- a/lib/instructions/instruction_names.c
+++ b/lib/instructions/instruction_names.c
@@ -2857,6 +2857,7 @@ const char* const* evmc_get_instruction_names_table(enum evmc_revision revision)
 {
     switch (revision)
     {
+    case EVMC_EXPERIMENTAL:
     case EVMC_OSAKA:
         return osaka_names;
     case EVMC_PRAGUE:

--- a/test/unittests/cpp_test.cpp
+++ b/test/unittests/cpp_test.cpp
@@ -919,6 +919,7 @@ TEST(cpp, revision_to_string)
         TEST_CASE(EVMC_CANCUN),
         TEST_CASE(EVMC_PRAGUE),
         TEST_CASE(EVMC_OSAKA),
+        TEST_CASE(EVMC_EXPERIMENTAL),
     };
 #undef TEST_CASE
 


### PR DESCRIPTION
Add new `EVMC_EXPERIMENTAL` to `evmc_revision` to allow EVM implementations to expose experimental features.