### PR TITLE
Increase the maximum gas that `--gas` accepts

### DIFF
--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, const char** argv) noexcept
         run_cmd.add_option("code", code_arg, "Bytecode")->required()->check(HexOrFile);
         run_cmd.add_option("--gas", gas, "Execution gas limit")
             ->capture_default_str()
-            ->check(CLI::Range(0, 1000000000));
+            ->check(CLI::Range(0L, 1000000000000L));
         run_cmd.add_option("--rev", rev, "EVM revision")->capture_default_str();
         run_cmd.add_option("--input", input_arg, "Input bytes")->check(HexOrFile);
         run_cmd.add_flag(

--- a/tools/evmc/main.cpp
+++ b/tools/evmc/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, const char** argv) noexcept
         run_cmd.add_option("code", code_arg, "Bytecode")->required()->check(HexOrFile);
         run_cmd.add_option("--gas", gas, "Execution gas limit")
             ->capture_default_str()
-            ->check(CLI::Range(0L, 1000000000000L));
+            ->check(CLI::Range(0LL, 1000000000000LL));
         run_cmd.add_option("--rev", rev, "EVM revision")->capture_default_str();
         run_cmd.add_option("--input", input_arg, "Input bytes")->check(HexOrFile);
         run_cmd.add_flag(


### PR DESCRIPTION
I'm doing some benchmarking and the default maximum gas limit is not enough to run my workload until completion, so this PR increases the maximum allowed value.